### PR TITLE
Make PythonLibs find_package python2 specific

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -23,7 +23,7 @@ target_link_libraries(tf2 ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(tf2 tf2_msgs_gencpp)
 
 #BEGIN Python Libraries
-find_package(PythonLibs REQUIRED)
+find_package(PythonLibs 2 REQUIRED)
 include_directories(${PYTHON_INCLUDE_PATH})
 
 # Check for SSE


### PR DESCRIPTION
On systems with python 3 installed and default, find_package(PythonLibs) will find the python 3 paths and libraries. However, the c++ include structure seems to be different in python 3 and tf2 uses includes that are no longer present or deprecated.

Until the includes are made to be python 3 compliant, we should specify that the version of python found must be python 2.
