### PR TITLE
Fix linkedit errors and compiler warnings on OS X

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(tf2)
 
 find_package(console_bridge REQUIRED)
-find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2_msgs rospy rostime)
-find_package(Boost REQUIRED COMPONENTS thread signals)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs rospy rostime tf2_msgs)
+find_package(Boost REQUIRED COMPONENTS signals system thread)
 
 catkin_package(
    INCLUDE_DIRS include
@@ -18,7 +18,7 @@ include_directories (src/bt)
 
 #CPP Libraries
 add_library(tf2 src/cache.cpp src/buffer_core.cpp src/static_cache.cpp)
-target_link_libraries(tf2 ${Boost_LIBRARIES} ${catkin_LIBRARIES})
+target_link_libraries(tf2 ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES})
 add_dependencies(tf2 tf2_msgs_gencpp)
 
 catkin_add_gtest(test_cache_unittest test/cache_unittest.cpp)

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -87,7 +87,7 @@ class BufferCore
 {
 public:
   /************* Constants ***********************/
-  static const double DEFAULT_CACHE_TIME = 10.0;  //!< The default amount of time to cache data in seconds
+  static const int DEFAULT_CACHE_TIME = 10;  //!< The default amount of time to cache data in seconds
   static const uint32_t MAX_GRAPH_DEPTH = 1000UL;  //!< The default amount of time to cache data in seconds
 
   /** Constructor

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -49,6 +49,7 @@
 #include <boost/unordered_map.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/function.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace tf2
 {
@@ -58,6 +59,7 @@ typedef uint32_t TransformableCallbackHandle;
 typedef uint64_t TransformableRequestHandle;
 
 class TimeCacheInterface;
+typedef boost::shared_ptr<TimeCacheInterface> TimeCacheInterfacePtr;
 
 enum TransformableResult
 {
@@ -300,7 +302,7 @@ private:
   
   /** \brief The pointers to potential frames that the tree can be made of.
    * The frames will be dynamically allocated at run time when set the first time. */
-  typedef std::vector<TimeCacheInterface*> V_TimeCacheInterface;
+  typedef std::vector<TimeCacheInterfacePtr> V_TimeCacheInterface;
   V_TimeCacheInterface frames_;
   
   /** \brief A mutex to protect testing and allocating new frames on the above vector. */
@@ -357,9 +359,9 @@ private:
    * This is an internal function which will get the pointer to the frame associated with the frame id
    * Possible Exception: tf::LookupException
    */
-  TimeCacheInterface* getFrame(CompactFrameID c_frame_id) const;
+  TimeCacheInterfacePtr getFrame(CompactFrameID c_frame_id) const;
 
-  TimeCacheInterface* allocateFrame(CompactFrameID cfid, bool is_static);
+  TimeCacheInterfacePtr allocateFrame(CompactFrameID cfid, bool is_static);
 
 
   bool warnFrameId(const char* function_name_arg, const std::string& frame_id) const;

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -41,6 +41,8 @@
 #include <ros/message_forward.h>
 #include <ros/time.h>
 
+#include <boost/shared_ptr.hpp>
+
 namespace geometry_msgs
 {
 ROS_DECLARE_MESSAGE(TransformStamped);
@@ -83,6 +85,7 @@ public:
   virtual ros::Time getOldestTimestamp()=0;
 };
 
+typedef boost::shared_ptr<TimeCacheInterface> TimeCacheInterfacePtr;
 
 /** \brief A class to keep a sorted linked list in time
  * This builds and maintains a list of timestamped

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -38,17 +38,8 @@
 #include <console_bridge/console.h>
 #include "tf2/LinearMath/Transform.h"
 
-//legacy
-//#include "tf/tf.h"
-//#include "tf/transform_datatypes.h"
-
 namespace tf2
 {
-
-// Must provide storage for non-integral static const class members.
-// Otherwise you get undefined symbol errors on OS X (why not on Linux?).
-// Thanks to Rob for pointing out the right way to do this.
-const double tf2::BufferCore::DEFAULT_CACHE_TIME;
 
 /** \brief convert Transform msg to Transform */
 void transformMsgToTF2(const geometry_msgs::Transform& msg, tf2::Transform& tf2)

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -453,7 +453,7 @@ static struct PyMethodDef buffer_core_methods[] =
 
 static PyMethodDef module_methods[] = {
   // {"Transformer", mkTransformer, METH_VARARGS},
-  {NULL, NULL, NULL},
+  {0, 0, 0},
 };
 
 extern "C" void init_tf2()


### PR DESCRIPTION
This fixes several things:

c45b7a5 fixes linkedit errors:

```
Linking CXX shared library /Users/william/nav_ws/devel_isolated/tf2/lib/libtf2.dylib
Undefined symbols for architecture x86_64:
  "console_bridge::log(char const*, int, console_bridge::LogLevel, char const*, ...)", referenced from:
      tf2::BufferCore::warnFrameId(char const*, std::string const&) const in buffer_core.cpp.o
      tf2::BufferCore::setTransform(geometry_msgs::TransformStamped_<std::allocator<void> > const&, std::string const&, bool) in buffer_core.cpp.o
      tf2::BufferCore::lookupTransform(std::string const&, std::string const&, ros::Time const&) const in buffer_core.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

b45a609 fixes compiler warnings:

```
/Users/william/nav_ws/install_isolated/include/tf2/buffer_core.h:90:23: warning: in-class initializer for static data member of type 'const double' is a GNU extension [-Wgnu]
  static const double DEFAULT_CACHE_TIME = 10.0;  //!< The default amount of time to cache data in seconds
```

This also removes an OS X specific fix which no longer applies. It now uses an int, but if that isn't ok we can use a define instead.

c5dbb6a Fixes a compiler warning by replacing the use of pointers with shared_ptr's:

```
/Users/william/nav_ws/src/geometry_experimental/tf2/src/buffer_core.cpp:273:5: warning: delete called on 'tf2::TimeCacheInterface' that is abstract but has non-virtual destructor
      [-Wdelete-non-virtual-dtor]
    delete frame_ptr;
```

Since it now uses a shared_ptr, there is no need to explicitly delete the object.

106f46d Fixes these compiler warnings:

```
/Users/william/nav_ws/src/tf/src/pytf.cpp:471:16: warning: implicit conversion of NULL constant to 'int' [-Wnull-conversion]
  {NULL, NULL, NULL},
  ~            ^~~~
               0
```

@tfoote thoughts?
