### PR TITLE
Fixed warning about null-conversion.

### DIFF
--- a/tf2/src/tf2_py.cpp
+++ b/tf2/src/tf2_py.cpp
@@ -453,7 +453,7 @@ static struct PyMethodDef buffer_core_methods[] =
 
 static PyMethodDef module_methods[] = {
   // {"Transformer", mkTransformer, METH_VARARGS},
-  {NULL, NULL, NULL},
+  {NULL, NULL, 0},
 };
 
 extern "C" void init_tf2()


### PR DESCRIPTION
The PyMethodDef sentinel should have a 0 instead of null for the 3rd member. This produces a warning when compiling:

```
warning: converting to non-pointer type ‘int’ from NULL [-Wconversion-null]
```
