### PR TITLE
tf2: add missing console bridge include directories (fix #48)

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -11,7 +11,7 @@ catkin_package(
    DEPENDS console_bridge
    CATKIN_DEPENDS geometry_msgs tf2_msgs rostime)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 include_directories (src/bt) 
 
 # export user definitions


### PR DESCRIPTION
@tfoote Please review, merge and release.
