### PR TITLE
Use ros::MessageEvent's in tf2_ros for connection information

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -60,9 +60,9 @@ private:
   void initWithThread();
 
   /// Callback function for ros message subscriptoin
-  void subscription_callback(const tf2_msgs::TFMessageConstPtr& msg);
-  void static_subscription_callback(const tf2_msgs::TFMessageConstPtr& msg);
-  void subscription_callback_impl(const tf2_msgs::TFMessageConstPtr& msg, bool is_static);
+  void subscription_callback(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt);
+  void static_subscription_callback(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt);
+  void subscription_callback_impl(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt, bool is_static);
 
   ros::CallbackQueue tf_message_callback_queue_;
   boost::thread* dedicated_listener_thread_;

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -90,34 +90,21 @@ void TransformListener::initWithThread()
 
 
 
-void TransformListener::subscription_callback(const tf2_msgs::TFMessageConstPtr& msg)
+void TransformListener::subscription_callback(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt)
 {
-  subscription_callback_impl(msg, false);
+  subscription_callback_impl(msg_evt, false);
 }
-void TransformListener::static_subscription_callback(const tf2_msgs::TFMessageConstPtr& msg)
+void TransformListener::static_subscription_callback(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt)
 {
-  subscription_callback_impl(msg, true);
+  subscription_callback_impl(msg_evt, true);
 }
 
-void TransformListener::subscription_callback_impl(const tf2_msgs::TFMessageConstPtr& msg, bool is_static)
+void TransformListener::subscription_callback_impl(const ros::MessageEvent<tf2_msgs::TFMessage>& msg_evt, bool is_static)
 {
-
-  const tf2_msgs::TFMessage& msg_in = *msg;
+  const tf2_msgs::TFMessage& msg_in = *(msg_evt.getConstMessage());
+  std::string authority = msg_evt.getPublisherName(); // lookup the authority
   for (unsigned int i = 0; i < msg_in.transforms.size(); i++)
   {
-    std::map<std::string, std::string>* msg_header_map = msg_in.__connection_header.get();
-    std::string authority;
-    std::map<std::string, std::string>::iterator it = msg_header_map->find("callerid");
-    if (it == msg_header_map->end())
-    {
-      ROS_WARN("Message recieved without callerid");
-      authority = "no callerid";
-    }
-    else 
-    {
-      authority = it->second;
-    }
-
     try
     {
       buffer_.setTransform(msg_in.transforms[i], authority, is_static);


### PR DESCRIPTION
Patch to stop using "__connection_header" field in ROS messages (for tf2_ros).
