### PR TITLE
make can_transform code return bool

### DIFF
--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -201,10 +201,7 @@ static PyObject *canTransformCore(PyObject *self, PyObject *args, PyObject *kw)
 
   if (!PyArg_ParseTupleAndKeywords(args, kw, "ssO&", (char**)keywords, &target_frame, &source_frame, rostime_converter, &time))
     return NULL;
-  std::string error_msg;
-  bool can_transform = bc->canTransform(target_frame, source_frame, time, &error_msg);
-  //return PyBool_FromLong(t->canTransform(target_frame, source_frame, time));
-  return Py_BuildValue("bs", can_transform, error_msg.c_str());
+  return PyBool_FromLong(bc->canTransform(target_frame, source_frame, time));
 }
 
 static PyObject *canTransformFullCore(PyObject *self, PyObject *args, PyObject *kw)
@@ -223,10 +220,7 @@ static PyObject *canTransformFullCore(PyObject *self, PyObject *args, PyObject *
                         &source_time,
                         &fixed_frame))
     return NULL;
-  std::string error_msg;
-  bool can_transform = bc->canTransform(target_frame, target_time, source_frame, source_time, fixed_frame, &error_msg);
-  //return PyBool_FromLong(t->canTransform(target_frame, target_time, source_frame, source_time, fixed_frame));
-  return Py_BuildValue("bs", can_transform, error_msg.c_str());
+  return PyBool_FromLong(bc->canTransform(target_frame, target_time, source_frame, source_time, fixed_frame));
 }
 
 /* Debugging stuff that may need to be implemented later


### PR DESCRIPTION
The current interface returns (bool, errorstr). This is nice to have, but it's
unintuitive and provokes the mistake "not buffer.can_transform(..)" which
should really be "not buffer.can_transform(..)[0]". Such a bug ( as currently
in tf2_ros/buffer.py:72 ) is much worse than receiving an error string without 
raising an exception.
