### PR TITLE
Fix the can_transform design flaw at the other end.

### DIFF
--- a/tf2_ros/src/tf2_ros/buffer.py
+++ b/tf2_ros/src/tf2_ros/buffer.py
@@ -68,19 +68,21 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
     def can_transform(self, target_frame, source_frame, time, timeout=rospy.Duration(0.0)):
         if timeout != rospy.Duration(0.0):
             start_time = rospy.Time.now()
+            r= rospy.Rate(20)
             while (rospy.Time.now() < start_time + timeout and 
-                   not self.can_transform_core(target_frame, source_frame, time) and
+                   not self.can_transform_core(target_frame, source_frame, time)[0] and
                    rospy.Time.now() >= start_time):
-                rospy.Duration(0.05).sleep()
+                r.sleep()
         return self.can_transform_core(target_frame, source_frame, time)
     
     # can, advanced api
     def can_transform_full(self, target_frame, target_time, source_frame, source_time, fixed_frame, timeout=rospy.Duration(0.0)):
         if timeout != rospy.Duration(0.0):
             start_time = rospy.Time.now()
+            r= rospy.Rate(20)
             while (rospy.Time.now() < start_time + timeout and 
-                   not self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame) and
+                   not self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)[0] and
                    rospy.Time.now() >= start_time):
-                rospy.Duration(0.05).sleep()
+                r.sleep()
         return self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)
 


### PR DESCRIPTION
As it's important to keep the API stable, let's fix
the only other end (mis)using the can_transform API
in the standard ROS distribution.

Also fix another bug which was never discovered due
to the broken can_transform check
