### PR TITLE
Removed AsyncSpinner workaround

### DIFF
--- a/test_tf2/test/test_buffer_client.cpp
+++ b/test_tf2/test/test_buffer_client.cpp
@@ -106,8 +106,6 @@ int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "buffer_client_test");
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
   return RUN_ALL_TESTS();
 }
 


### PR DESCRIPTION
AsyncSpinner workaround no longer needed after ros/actionlib#26 got merged
