### PR TITLE
Make transform_listener reset tf buffer on loop detection

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -70,6 +70,7 @@ private:
   ros::Subscriber message_subscriber_tf_;
   ros::Subscriber message_subscriber_tf_static_;
   tf2::BufferCore& buffer_;
+  ros::Time last_update_;
   bool using_dedicated_thread_;
  
   void dedicatedListenerThread()

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -101,6 +101,12 @@ void TransformListener::static_subscription_callback(const tf2_msgs::TFMessageCo
 
 void TransformListener::subscription_callback_impl(const tf2_msgs::TFMessageConstPtr& msg, bool is_static)
 {
+  ros::Time now = ros::Time::now();
+  if(now < last_update_){
+    ROS_WARN("Detected jump back in time. Clearing TF buffer.");
+    buffer_.clear();
+  }
+  last_update_ = now;
 
   const tf2_msgs::TFMessage& msg_in = *msg;
   for (unsigned int i = 0; i < msg_in.transforms.size(); i++)


### PR DESCRIPTION
This makes tf2 work with `rosbag --clock --loop` as expected.

For some reason rostime does not use CLOCK_MONOTONIC,
so I'm not sure whether we should allow for tiny backjumps (< 1s).
I know for sure this is an issue with the rospy API at least.

Also addresses issue #64.
