### PR TITLE
Fix setting proper header for transformed pointcloud

### DIFF
--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -56,6 +56,7 @@ template <>
 void doTransform(const sensor_msgs::PointCloud2 &p_in, sensor_msgs::PointCloud2 &p_out, const geometry_msgs::TransformStamped& t_in)
 {
   p_out = p_in;
+  p_out.header = t_in.header;
   Eigen::Transform<float,3,Eigen::Affine> t = Eigen::Translation3f(t_in.transform.translation.x, t_in.transform.translation.y,
                                                                    t_in.transform.translation.z) * Eigen::Quaternion<float>(
                                                                      t_in.transform.rotation.w, t_in.transform.rotation.x,


### PR DESCRIPTION
Straightforward fix, header was previously being left identical to incoming pointcloud.
