### PR TITLE
Fix static broadcaster with rpy args

### DIFF
--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -81,7 +81,7 @@ int main(int argc, char ** argv)
     msg.transform.translation.z = atof(argv[3]);
 
     tf2::Quaternion quat;
-    quat.setRPY(atof(argv[3]), atof(argv[2]), atof(argv[1]));
+    quat.setRPY(atof(argv[6]), atof(argv[5]), atof(argv[4]));
     msg.transform.rotation.x = quat.x();
     msg.transform.rotation.y = quat.y();
     msg.transform.rotation.z = quat.z();

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -29,6 +29,7 @@
 
 #include <math.h>
 #include <cstdio>
+#include <tf2/LinearMath/Quaternion.h>
 #include "tf2_ros/static_transform_broadcaster.h"
 
 int main(int argc, char ** argv)
@@ -78,21 +79,14 @@ int main(int argc, char ** argv)
     msg.transform.translation.x = atof(argv[1]);
     msg.transform.translation.y = atof(argv[2]);
     msg.transform.translation.z = atof(argv[3]);
-    
-    double halfYaw = atof(argv[4]) * 0.5;
-    double halfPitch = atof(argv[5]) * 0.5;
-    double halfRoll = atof(argv[6]) * 0.5;
-    double cosYaw = cos(halfYaw);
-    double sinYaw = sin(halfYaw);
-    double cosPitch = cos(halfPitch);
-    double sinPitch = sin(halfPitch);
-    double cosRoll = cos(halfRoll);
-    double sinRoll = sin(halfRoll);
-    
-    msg.transform.rotation.x = sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw;
-    msg.transform.rotation.y = cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw;
-    msg.transform.rotation.z = cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw;
-    msg.transform.rotation.w = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
+
+    tf2::Quaternion quat;
+    quat.setRPY(atof(argv[3]), atof(argv[2]), atof(argv[1]));
+    msg.transform.rotation.x = quat.x();
+    msg.transform.rotation.y = quat.y();
+    msg.transform.rotation.z = quat.z();
+    msg.transform.rotation.w = quat.w();
+
     msg.header.stamp = ros::Time::now();
     msg.header.frame_id = argv[7];
     msg.child_frame_id = argv[8];

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
 {
   //Initialize ROS
   ros::init(argc, argv,"static_transform_publisher", ros::init_options::AnonymousName);
-  tf2_ros::StaticTransformBroadcaster broadcaaster;
+  tf2_ros::StaticTransformBroadcaster broadcaster;
 
   if(argc == 10)
   {
@@ -61,7 +61,7 @@ int main(int argc, char ** argv)
   
 
 
-  broadcaaster.sendTransform(msg);
+  broadcaster.sendTransform(msg);
   ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
   ros::spin();
 
@@ -91,7 +91,7 @@ int main(int argc, char ** argv)
     msg.header.frame_id = argv[7];
     msg.child_frame_id = argv[8];
 
-    broadcaaster.sendTransform(msg);
+    broadcaster.sendTransform(msg);
     ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
     ros::spin();
     return 0;

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -27,7 +27,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <math.h>
 #include <cstdio>
 #include <tf2/LinearMath/Quaternion.h>
 #include "tf2_ros/static_transform_broadcaster.h"

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -93,7 +93,9 @@ int main(int argc, char ** argv)
     msg.transform.rotation.y = cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw;
     msg.transform.rotation.z = cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw;
     msg.transform.rotation.w = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
-
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = argv[7];
+    msg.child_frame_id = argv[8];
 
     broadcaaster.sendTransform(msg);
     ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());


### PR DESCRIPTION
static_transform_publisher was not setting the header properly for the RPY version of the input args.

Just like in tf(1), the parameters are provided backwards as x y z yaw pitch roll. Maybe a note should be added to specify that these are NOT Euler angles?
