### PR TITLE
fix deadlock

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -305,7 +305,6 @@ public:
       return;
     }
 
-    boost::mutex::scoped_lock lock(messages_mutex_);
     // iterate through the target frames and add requests for each of them
     MessageInfo info;
     info.handles.reserve(expected_success_count_);
@@ -350,6 +349,7 @@ public:
       }
     }
 
+    boost::mutex::scoped_lock lock(messages_mutex_);
     // We can transform already
     if (info.success_count == expected_success_count_)
     {


### PR DESCRIPTION
THAT WAS NOT FUN ! I SPENT A DAY ON THAT !
But it makes navigation work with tf2 so it's ok :)

Here is what's happening in some navigation tests I am switching to tf2.
In buffer_core.cpp, line 1298, a callback is being called in
testTransformableRequests after locking transformable_requests_mutex_
line 1256. This is actually defined through a message_filter. It is a
transformable that is being executed: it therefore locks
messages_mutex_ line 449 in message_filter.h. At the same time, a
message is added and the same mutex is locked line 308 in add but
line 321, a transformable is also added to the list in buffer_core
which calls a lock on transformable_requests_mutex_ line 1164 in
addTransformableRequest. Hence a deadlock.
