### PR TITLE
Remove unused assignments in max/min functions

### DIFF
--- a/tf2/include/tf2/LinearMath/Vector3.h
+++ b/tf2/include/tf2/LinearMath/Vector3.h
@@ -538,7 +538,6 @@ public:
 		if (m_floats[3] > maxVal)
 		{
 			maxIndex = 3;
-			maxVal = m_floats[3];
 		}
 		
 		
@@ -571,7 +570,6 @@ public:
 		if (m_floats[3] < minVal)
 		{
 			minIndex = 3;
-			minVal = m_floats[3];
 		}
 		
 		return minIndex;


### PR DESCRIPTION
While running clang's static analysis on my own code, it complains (correctly) about unused assignments in tf2. These assignments to maxVal/minVal are unnecessary because they never get read after this point.
