### PR TITLE
Use overloading instead of default arguments

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -212,7 +212,11 @@ public:
   /** \brief A way to see what frames have been cached in yaml format
    * Useful for debugging tools
    */
-  std::string allFramesAsYAML(double current_time = 0) const;
+  std::string allFramesAsYAML(double current_time) const;
+
+  /** Backwards compatibility for #84
+  */
+  std::string allFramesAsYAML() const;
 
   /** \brief A way to see what frames have been cached
    * Useful for debugging

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -297,7 +297,8 @@ public:
   /** \brief Backwards compatabilityA way to see what frames have been cached
    * Useful for debugging
    */
-  std::string _allFramesAsDot(double current_time = 0) const;
+  std::string _allFramesAsDot(double current_time) const;
+  std::string _allFramesAsDot() const;
 
   /** \brief Backwards compatabilityA way to see what frames are in a chain
    * Useful for debugging

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -275,7 +275,7 @@ TimeCacheInterfacePtr BufferCore::allocateFrame(CompactFrameID cfid, bool is_sta
   } else {
     frames_[cfid] = TimeCacheInterfacePtr(new TimeCache(cache_time_));
   }
-  
+
   return frames_[cfid];
 }
 
@@ -1073,6 +1073,11 @@ std::string BufferCore::allFramesAsYAML(double current_time) const
   }
 
   return mstream.str();
+}
+
+std::string BufferCore::allFramesAsYAML() const
+{
+  return this->allFramesAsYAML(0.0);
 }
 
 TransformableCallbackHandle BufferCore::addTransformableCallback(const TransformableCallback& cb)

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1409,6 +1409,10 @@ std::string BufferCore::_allFramesAsDot(double current_time) const
   return mstream.str();
 }
 
+std::string BufferCore::_allFramesAsDot() const
+{
+  return _allFramesAsDot(0.0);
+}
 
 void BufferCore::_chainAsVector(const std::string & target_frame, ros::Time target_time, const std::string & source_frame, ros::Time source_time, const std::string& fixed_frame, std::vector<std::string>& output) const
 {


### PR DESCRIPTION
This has better backwards compatibility for symbols. 
Fixes #84
