### PR TITLE
same queue size of transform boradcaster in c++ and Python

### DIFF
--- a/tf2_ros/src/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros/src/tf2_ros/transform_broadcaster.py
@@ -41,7 +41,7 @@ class TransformBroadcaster:
     """
 
     def __init__(self):
-        self.pub_tf = rospy.Publisher("/tf", TFMessage, queue_size=1)
+        self.pub_tf = rospy.Publisher("/tf", TFMessage, queue_size=100)
 
     def sendTransform(self, transform):
         if not isinstance(transform, list):


### PR DESCRIPTION
Fix for issue #89 

As tfoote mentions in the issue, it should probably be set to an optional parameter when instantiating the transform broadcaster. 
