### PR TITLE
Enabled build of tf2 python documentation

### DIFF
--- a/tf2_ros/conf.py
+++ b/tf2_ros/conf.py
@@ -199,7 +199,6 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'http://docs.python.org/': None,
-    'http://opencv.willowgarage.com/documentation/': None,
-    'http://opencv.willowgarage.com/documentation/python/': None,
+    'http://docs.opencv.org/3.0-last-rst/': None,
     'http://docs.scipy.org/doc/numpy' : None
     }

--- a/tf2_ros/index.rst
+++ b/tf2_ros/index.rst
@@ -1,0 +1,15 @@
+tf2_ros
+=====
+
+This is the Python API reference of the tf2_ros package. 
+
+.. toctree::
+    :maxdepth: 2
+
+    tf2_ros
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`search`


### PR DESCRIPTION
Enable Sphinx documentation for tf2_ros for issue #52 and removed dead `opencv.willowgarage.com` link from `tf2_ros/conf.py` to speed up documentation generation. `rosdoc_lite tf2_ros` now generates a `python/tf2_ros.html` file from `index.rst` and `tf2_ros.rst`. The documentation could still probably use some work, and I'm not sure whether or not the directory structure needs to be changed on the docs server. @tfoote can advise.

Connects to #52
