### PR TITLE
break canTransform loop only for non-tiny negative time deltas

### DIFF
--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -124,7 +124,7 @@ Buffer::canTransform(const std::string& target_frame, const std::string& source_
   ros::Time start_time = now_fallback_to_wall();
   while (now_fallback_to_wall() < start_time + timeout && 
          !canTransform(target_frame, source_frame, time) &&
-         now_fallback_to_wall() >= start_time &&  //don't wait if time jumped backwards
+         (now_fallback_to_wall()+ros::Duration(3.0) >= start_time) &&  //don't wait when we detect a bag loop
          (ros::ok() || !ros::isInitialized())) // Make sure we haven't been stopped (won't work for pytf)
     {
       sleep_fallback_to_wall(ros::Duration(0.01));
@@ -147,7 +147,7 @@ Buffer::canTransform(const std::string& target_frame, const ros::Time& target_ti
   ros::Time start_time = now_fallback_to_wall();
   while (now_fallback_to_wall() < start_time + timeout && 
          !canTransform(target_frame, target_time, source_frame, source_time, fixed_frame) &&
-         now_fallback_to_wall() >= start_time &&  //don't wait if time jumped backwards
+         (now_fallback_to_wall()+ros::Duration(3.0) >= start_time) &&  //don't wait when we detect a bag loop
          (ros::ok() || !ros::isInitialized())) // Make sure we haven't been stopped (won't work for pytf)
          {  
            sleep_fallback_to_wall(ros::Duration(0.01));

--- a/tf2_ros/src/tf2_ros/buffer.py
+++ b/tf2_ros/src/tf2_ros/buffer.py
@@ -71,7 +71,7 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
             r= rospy.Rate(20)
             while (rospy.Time.now() < start_time + timeout and 
                    not self.can_transform_core(target_frame, source_frame, time)[0] and
-                   rospy.Time.now() >= start_time):
+                   (rospy.Time.now()+rospy.Duration(3.0)) >= start_time): # big jumps in time are likely bag loops, so break for them
                 r.sleep()
         core_result = self.can_transform_core(target_frame, source_frame, time)
         if return_debug_tuple:
@@ -86,7 +86,7 @@ class Buffer(tf2.BufferCore, tf2_ros.BufferInterface):
             r= rospy.Rate(20)
             while (rospy.Time.now() < start_time + timeout and 
                    not self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)[0] and
-                   rospy.Time.now() >= start_time):
+                   (rospy.Time.now()+rospy.Duration(3.0)) >= start_time): # big jumps in time are likely bag loops, so break for them
                 r.sleep()
         core_result = self.can_transform_full_core(target_frame, target_time, source_frame, source_time, fixed_frame)
         if return_debug_tuple:


### PR DESCRIPTION
(At least) with Python 2 ros.Time.now() is not necessarily monotonic and one
can experience negative time deltas (usually well below 1s) on real hardware
under full load. This check was originally introduced to allow for backjumps
with rosbag replays, and only there it makes sense. So we'll add a small
duration threshold to ignore backjumps due to non-monotonic clocks.

I tested this with one of our robot setups where the problem appears about always.

Old behaviour:

```
tfl= tf.TransformListener()
n=now(); tfl.waitForTransform('base_link', 'map', n, rospy.Duration(5))
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-15-f54fb911f11f> in <module>()
----> 1 n=now(); tfl.waitForTransform('base_link', 'map', n, rospy.Duration(5))

Exception: Lookup would require extrapolation into the future.  Requested time 1430299947.377846003 but the latest data is at time 1430299947.341470242, when looking up transform from frame [map] to frame [base_link]
```

The exception is thrown right away without waiting for 5 seconds.

With this patch, the above works as expected.

I would actually prefer to fix this via https://github.com/v4hn/geometry_experimental/commit/97280675e376d90354ce304ef9ed77829e0bb477,
BUT this breaks python tf (one). Its implementation uses the patched canTransform method
of the C++ tf2_ros/Buffer class instead of implementing its own one, the way the
python tf2_ros Buffer does it. That way, rosparameters are not available to the C++
tf2_ros/Buffer class when constructed from tf.TransformListener in python
and the NodeHandle constructor throws an exception.
(there is no ros-context initialized for the C++ code)
