### PR TITLE
provide more conversions between types

### DIFF
--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -38,6 +38,7 @@
 #include <tf2/convert.h>
 #include <tf2_kdl/tf2_kdl.h>
 #include <tf2_bullet/tf2_bullet.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <ros/time.h>
 
 TEST(tf2Convert, kdlToBullet)
@@ -65,7 +66,35 @@ TEST(tf2Convert, kdlToBullet)
   EXPECT_NEAR(b1.x(), b2.x(), epsilon);
   EXPECT_NEAR(b1.y(), b2.y(), epsilon);
   EXPECT_NEAR(b1.z(), b2.z(), epsilon);
+}
 
+TEST(tf2Convert, kdlBulletROSConversions)
+{
+  double epsilon = 1e-9;
+
+  tf2::Stamped<btVector3> b1(btVector3(1,2,3), ros::Time(), "my_frame"), b2, b3, b4;
+  geometry_msgs::PointStamped r1, r2, r3;
+  tf2::Stamped<KDL::Vector> k1, k2, k3;
+
+  // Do bullet -> self -> bullet -> KDL -> self -> KDL -> ROS -> self -> ROS -> KDL -> bullet -> ROS -> bullet
+  tf2::convert(b1, b1);
+  tf2::convert(b1, b2);
+  tf2::convert(b2, k1);
+  tf2::convert(k1, k1);
+  tf2::convert(k1, k2);
+  tf2::convert(k2, r1);
+  tf2::convert(r1, r1);
+  tf2::convert(r1, r2);
+  tf2::convert(r2, k3);
+  tf2::convert(k3, b3);
+  tf2::convert(b3, r3);
+  tf2::convert(r3, b4);
+
+  EXPECT_EQ(b1.frame_id_, b4.frame_id_);
+  EXPECT_NEAR(b1.stamp_.toSec(), b4.stamp_.toSec(), epsilon);
+  EXPECT_NEAR(b1.x(), b4.x(), epsilon);
+  EXPECT_NEAR(b1.y(), b4.y(), epsilon);
+  EXPECT_NEAR(b1.z(), b4.z(), epsilon);
 } 
 
 int main(int argc, char** argv)

--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -95,7 +95,25 @@ TEST(tf2Convert, kdlBulletROSConversions)
   EXPECT_NEAR(b1.x(), b4.x(), epsilon);
   EXPECT_NEAR(b1.y(), b4.y(), epsilon);
   EXPECT_NEAR(b1.z(), b4.z(), epsilon);
-} 
+
+  // The following should simply compile, that's it
+  r2 = tf2::toMsg(r1);
+  tf2::fromMsg(r2, r3);
+
+  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
+  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
+  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
+
+  r1 = tf2::toMsg(r1);
+  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
+  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
+  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
+
+  tf2::fromMsg(r1, r1);
+  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
+  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
+  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
+}
 
 int main(int argc, char** argv)
 {

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -36,7 +36,7 @@
 #include <tf2/transform_datatypes.h>
 #include <tf2/exceptions.h>
 #include <geometry_msgs/TransformStamped.h>
-
+#include <tf2/impl/convert.h>
 
 namespace tf2 {
 
@@ -82,11 +82,18 @@ template <class P>
     return t.frame_id_;
   }
 
+/** Function that converts any type to any type (messages or not).
+ * Matching toMsg and from Msg conversion functions need to exist.
+ * If they don't exist or do not apply (for example, if your two
+ * classes are messages), just write a specialization of the function.
+ * \param a the object to convert
+ * \param b the object to convert to
+ */
 template <class A, class B>
   void convert(const A& a, B& b)
   {
     //printf("In double type convert\n");
-    fromMsg(toMsg(a), b);
+    impl::Converter<ros::message_traits::IsMessage<A>::value, ros::message_traits::IsMessage<B>::value>::convert(a, b);
   }
 
 template <class A>

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -82,11 +82,64 @@ template <class P>
     return t.frame_id_;
   }
 
+/** Function that converts from one type to a ROS message type. It has to be
+ * implemented by each data type in tf2_* (except ROS messages) as it is
+ * used in the "convert" function.
+ * \param a an object of whatever type
+ * \return the conversion as a ROS message
+ */
+template<typename A, typename B>
+  B toMsg(const A& a);
+
+/** Function that converts from one type to a ROS message type. This is the
+ * specialization of the two argument template. It will not compile for an
+ * object that is not a ROS message. Inside the "convert" function, it is
+ * optimized out.
+ * \param a a ROS message
+ * \return a copy of the same ROS message
+ */
+template<typename A>
+  A toMsg(const A& a) {
+    // Make sure that we are dealing with a message
+    // If your code does not compile and refers to that line, it's because
+    // you are using toMsg for something that is not a ROS message, e.g toMsg(int)
+    // This is a C++03 version of a static_assert
+    static bool _is_message[ros::message_traits::IsMessage<A>::value ? 1 : -1];
+    return a;
+  }
+
+/** Function that converts from a ROS message type to another type. It has to be
+ * implemented by each data type in tf2_* (except ROS messages) as it is used
+ * in the "convert" function.
+ * \param a a ROS message to convert from
+ * \param b the object to convert to
+ */
+template<typename A, typename B>
+  void fromMsg(const A&, B& b);
+
+/** Function that converts from one type to a ROS message type. This is the
+ * specialization of the two argument template. It will not compile for an
+ * object that is not a ROS message. Inside the "convert" function, it is
+ * optimized out.
+ * \param a a ROS message to convert from
+ * \param b a ROS message of the same type as the first one
+ */
+template<typename A>
+  void fromMsg(const A& a, A& b) {
+    // Make sure that we are dealing with a message
+    // If your code does not compile and refers to that line, it's because
+    // you are using fromMsg for something that is not a ROS message
+    // This is a C++03 version of a static_assert
+    static bool _is_message[ros::message_traits::IsMessage<A>::value ? 1 : -1];
+    if(&a != &b)
+        b = a;
+  }
+
 /** Function that converts any type to any type (messages or not).
  * Matching toMsg and from Msg conversion functions need to exist.
  * If they don't exist or do not apply (for example, if your two
- * classes are messages), just write a specialization of the function.
- * \param a the object to convert
+ * classes are ROS messages), just write a specialization of the function.
+ * \param a an object to convert from
  * \param b the object to convert to
  */
 template <class A, class B>

--- a/tf2/include/tf2/impl/convert.h
+++ b/tf2/include/tf2/impl/convert.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2013, Open Source Robotics Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_IMPL_CONVERT_H
+#define TF2_IMPL_CONVERT_H
+
+namespace tf2 {
+namespace impl {
+
+template <bool IS_MESSAGE_A, bool IS_MESSAGE_B>
+class Converter {
+public:
+  template<typename A, typename B>
+  static void convert(const A& a, B& b);
+};
+
+// The case where both A and B are messages should not happen: if you have two
+// messages that are interchangeable, well, that's against the ROS purpose:
+// only use one type. Worst comes to worst, specialize the original convert
+// function for your types.
+// if B == A, the templated version of convert with only one argument will be
+// used.
+//
+//template <>
+//template <typename A, typename B>
+//inline void Converter<true, true>::convert(const A& a, B& b);
+
+template <>
+template <typename A, typename B>
+inline void Converter<true, false>::convert(const A& a, B& b)
+{
+  fromMsg(a, b);
+}
+
+template <>
+template <typename A, typename B>
+inline void Converter<false, true>::convert(const A& a, B& b)
+{
+  b = toMsg(a);
+}
+
+template <>
+template <typename A, typename B>
+inline void Converter<false, false>::convert(const A& a, B& b)
+{
+  fromMsg(toMsg(a), b);
+}
+
+}
+}
+
+#endif //TF2_IMPL_CONVERT_H

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -81,16 +81,6 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
-inline
-geometry_msgs::Vector3Stamped toMsg(const geometry_msgs::Vector3Stamped& in)
-{
-  return in;
-}
-inline
-void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Stamped& out)
-{
-  out = msg;
-}
 
 
 
@@ -120,16 +110,6 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
-inline
-geometry_msgs::PointStamped toMsg(const geometry_msgs::PointStamped& in)
-{
-  return in;
-}
-inline
-void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped& out)
-{
-  out = msg;
-}
 
 
 /*****************/
@@ -162,16 +142,6 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
-inline
-geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
-{
-  return in;
-}
-inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& out)
-{
-  out = msg;
-}
 
 
 /****************/
@@ -223,16 +193,6 @@ void doTransform(const geometry_msgs::QuaternionStamped& t_in, geometry_msgs::Qu
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
 }
-inline
-geometry_msgs::QuaternionStamped toMsg(const geometry_msgs::QuaternionStamped& in)
-{
-  return in;
-}
-inline
-void fromMsg(const geometry_msgs::QuaternionStamped& msg, geometry_msgs::QuaternionStamped& out)
-{
-  out = msg;
-}
 
 
 /**********************/
@@ -268,16 +228,6 @@ void doTransform(const geometry_msgs::TransformStamped& t_in, geometry_msgs::Tra
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
-inline
-geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
-{
-  return in;
-}
-inline
-void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)
-{
-  out = msg;
-}
 
 
 /***************/

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -81,16 +81,6 @@ void doTransform(const sensor_msgs::PointCloud2 &p_in, sensor_msgs::PointCloud2 
     *z_out = point.z();
   }
 }
-inline
-sensor_msgs::PointCloud2 toMsg(const sensor_msgs::PointCloud2 &in)
-{
-  return in;
-}
-inline
-void fromMsg(const sensor_msgs::PointCloud2 &msg, sensor_msgs::PointCloud2 &out)
-{
-  out = msg;
-}
 
 } // namespace
 


### PR DESCRIPTION
The previous conversion always assumed that it was converting a
non-message type to a non-message type. Now, one, both or none
can be a message or a non-message.
