### PR TITLE
Revert "officialize toMsg and fromMsg by adding them to convert"

### DIFF
--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -95,25 +95,7 @@ TEST(tf2Convert, kdlBulletROSConversions)
   EXPECT_NEAR(b1.x(), b4.x(), epsilon);
   EXPECT_NEAR(b1.y(), b4.y(), epsilon);
   EXPECT_NEAR(b1.z(), b4.z(), epsilon);
-
-  // The following should simply compile, that's it
-  r2 = tf2::toMsg(r1);
-  tf2::fromMsg(r2, r3);
-
-  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
-  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
-  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
-
-  r1 = tf2::toMsg(r1);
-  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
-  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
-  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
-
-  tf2::fromMsg(r1, r1);
-  EXPECT_NEAR(r1.point.x, r3.point.x, epsilon);
-  EXPECT_NEAR(r1.point.y, r3.point.y, epsilon);
-  EXPECT_NEAR(r1.point.z, r3.point.z, epsilon);
-}
+} 
 
 int main(int argc, char** argv)
 {

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -91,23 +91,6 @@ template <class P>
 template<typename A, typename B>
   B toMsg(const A& a);
 
-/** Function that converts from one type to a ROS message type. This is the
- * specialization of the two argument template. It will not compile for an
- * object that is not a ROS message. Inside the "convert" function, it is
- * optimized out.
- * \param a a ROS message
- * \return a copy of the same ROS message
- */
-template<typename A>
-  A toMsg(const A& a) {
-    // Make sure that we are dealing with a message
-    // If your code does not compile and refers to that line, it's because
-    // you are using toMsg for something that is not a ROS message, e.g toMsg(int)
-    // This is a C++03 version of a static_assert
-    static bool _is_message[ros::message_traits::IsMessage<A>::value ? 1 : -1];
-    return a;
-  }
-
 /** Function that converts from a ROS message type to another type. It has to be
  * implemented by each data type in tf2_* (except ROS messages) as it is used
  * in the "convert" function.
@@ -116,24 +99,6 @@ template<typename A>
  */
 template<typename A, typename B>
   void fromMsg(const A&, B& b);
-
-/** Function that converts from one type to a ROS message type. This is the
- * specialization of the two argument template. It will not compile for an
- * object that is not a ROS message. Inside the "convert" function, it is
- * optimized out.
- * \param a a ROS message to convert from
- * \param b a ROS message of the same type as the first one
- */
-template<typename A>
-  void fromMsg(const A& a, A& b) {
-    // Make sure that we are dealing with a message
-    // If your code does not compile and refers to that line, it's because
-    // you are using fromMsg for something that is not a ROS message
-    // This is a C++03 version of a static_assert
-    static bool _is_message[ros::message_traits::IsMessage<A>::value ? 1 : -1];
-    if(&a != &b)
-        b = a;
-  }
 
 /** Function that converts any type to any type (messages or not).
  * Matching toMsg and from Msg conversion functions need to exist.

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -81,6 +81,16 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+inline
+geometry_msgs::Vector3Stamped toMsg(const geometry_msgs::Vector3Stamped& in)
+{
+  return in;
+}
+inline
+void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Stamped& out)
+{
+  out = msg;
+}
 
 
 
@@ -110,6 +120,16 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+inline
+geometry_msgs::PointStamped toMsg(const geometry_msgs::PointStamped& in)
+{
+  return in;
+}
+inline
+void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped& out)
+{
+  out = msg;
+}
 
 
 /*****************/
@@ -142,6 +162,16 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+inline
+geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
+{
+  return in;
+}
+inline
+void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& out)
+{
+  out = msg;
+}
 
 
 /****************/
@@ -193,6 +223,16 @@ void doTransform(const geometry_msgs::QuaternionStamped& t_in, geometry_msgs::Qu
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
 }
+inline
+geometry_msgs::QuaternionStamped toMsg(const geometry_msgs::QuaternionStamped& in)
+{
+  return in;
+}
+inline
+void fromMsg(const geometry_msgs::QuaternionStamped& msg, geometry_msgs::QuaternionStamped& out)
+{
+  out = msg;
+}
 
 
 /**********************/
@@ -228,6 +268,16 @@ void doTransform(const geometry_msgs::TransformStamped& t_in, geometry_msgs::Tra
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+inline
+geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
+{
+  return in;
+}
+inline
+void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)
+{
+  out = msg;
+}
 
 
 /***************/

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -81,6 +81,16 @@ void doTransform(const sensor_msgs::PointCloud2 &p_in, sensor_msgs::PointCloud2 
     *z_out = point.z();
   }
 }
+inline
+sensor_msgs::PointCloud2 toMsg(const sensor_msgs::PointCloud2 &in)
+{
+  return in;
+}
+inline
+void fromMsg(const sensor_msgs::PointCloud2 &msg, sensor_msgs::PointCloud2 &out)
+{
+  out = msg;
+}
 
 } // namespace
 


### PR DESCRIPTION
This reverts commit ea87ea91e67b5f1ed28134cafeea8a1c6329e7ec.

We just don't want to break the ABI
