### PR TITLE
Fix do_transform_cloud for python

### DIFF
--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -37,7 +37,10 @@
   <run_depend>tf2_msgs</run_depend>
   <run_depend>tf2_py</run_depend>
 
-  <test_depend>rostest</test_depend>g
+  <test_depend>rostest</test_depend>
+
+
+
 
 </package>
 

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -33,9 +33,9 @@ add_executable(test_tf2_sensor_msgs_cpp EXCLUDE_FROM_ALL test/test_tf2_sensor_ms
 target_link_libraries(test_tf2_sensor_msgs_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
 
-#if(TARGET tests)
-#  add_dependencies(tests test_tf2_sensor_msgs_cpp)
-#endif()
+if(TARGET tests)
+  add_dependencies(tests test_tf2_sensor_msgs_cpp)
+endif()
 add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
 
 

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -23,6 +23,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 catkin_python_setup()
 
 if(CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/test_tf2_sensor_msgs.py)
 
 find_package(catkin REQUIRED COMPONENTS sensor_msgs rostest tf2_ros tf2)
 
@@ -32,9 +33,9 @@ add_executable(test_tf2_sensor_msgs_cpp EXCLUDE_FROM_ALL test/test_tf2_sensor_ms
 target_link_libraries(test_tf2_sensor_msgs_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
 
-if(TARGET tests)
-  add_dependencies(tests test_tf2_sensor_msgs_cpp)
-endif()
+#if(TARGET tests)
+#  add_dependencies(tests test_tf2_sensor_msgs_cpp)
+#endif()
 add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
 
 

--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -15,9 +15,9 @@
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2_ros</build_depend>
   <build_depend>tf2</build_depend>
- 
+  <build_depend>tf2_ros</build_depend>
+
   <run_depend>cmake_modules</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>sensor_msgs</run_depend>
@@ -25,5 +25,6 @@
   <run_depend>tf2</run_depend>
 
   <test_depend>rostest</test_depend>
+
 </package>
 

--- a/tf2_sensor_msgs/src/tf2_sensor_msgs/__init__.py
+++ b/tf2_sensor_msgs/src/tf2_sensor_msgs/__init__.py
@@ -1,1 +1,1 @@
-from tf2_geometry_msgs import *
+from tf2_sensor_msgs import *

--- a/tf2_sensor_msgs/src/tf2_sensor_msgs/tf2_sensor_msgs.py
+++ b/tf2_sensor_msgs/src/tf2_sensor_msgs/tf2_sensor_msgs.py
@@ -26,10 +26,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from sensor_msgs.msg import PointCloud2
+from sensor_msgs.point_cloud2 import read_points, create_cloud
 import PyKDL
 import rospy
 import tf2_ros
-from sensor_msgs.point_cloud2 import read_cloud
 
 def to_msg_msg(msg):
     return msg
@@ -50,13 +50,11 @@ def transform_to_kdl(t):
 
 # PointStamped
 def do_transform_cloud(cloud, transform):
-    res = cloud.copy()
     t_kdl = transform_to_kdl(transform)
-    for p_in, p_out in [ read_cloud(cloud), read_cloud(res) ]:
-        p = t_kdl * PyKDL.Vector(p_in.x, p_in.y, p_in.z)
-        p_out.x = p[0]
-        p_out.y = p[1]
-        p_out.z = p[2]
-    res.header = transform.header
+    points_out = []
+    for p_in in read_points(cloud):
+        p_out = t_kdl * PyKDL.Vector(p_in[0], p_in[1], p_in[2])
+        points_out.append(p_out)
+    res = create_cloud(transform.header, cloud.fields, points_out)
     return res
 tf2_ros.TransformRegistration().add(PointCloud2, do_transform_cloud)

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+import roslib
+
+import sys
+import unittest
+import struct
+import tf2_sensor_msgs
+from sensor_msgs import point_cloud2
+from sensor_msgs.msg import PointField
+from tf2_ros import TransformStamped
+import copy
+import rospy
+
+## A sample python unit test
+class PointCloudConversions(unittest.TestCase):
+    def setUp(self):
+        self.point_cloud_in = point_cloud2.PointCloud2()
+        self.point_cloud_in.fields = [PointField('x', 0, PointField.FLOAT32, 1),
+                                PointField('y', 4, PointField.FLOAT32, 1),
+                                PointField('z', 8, PointField.FLOAT32, 1)]
+
+        self.point_cloud_in.point_step = 4 * 3
+        self.point_cloud_in.height = 1
+        # we add two points (with x, y, z to the cloud)
+        self.point_cloud_in.width = 2
+        self.point_cloud_in.row_step = self.point_cloud_in.point_step * self.point_cloud_in.width
+
+        points = [1, 2, 0, 10, 20, 30]
+        self.point_cloud_in.data = struct.pack('%sf' % len(points), *points)
+
+
+        self.transform_translate_xyz_300 = TransformStamped()
+        self.transform_translate_xyz_300.transform.translation.x = 300
+        self.transform_translate_xyz_300.transform.translation.y = 300
+        self.transform_translate_xyz_300.transform.translation.z = 300
+        self.transform_translate_xyz_300.transform.rotation.w = 1  # no rotation so we only set w
+
+        assert(list(point_cloud2.read_points(self.point_cloud_in)) == [(1.0, 2.0, 0.0), (10.0, 20.0, 30.0)])
+
+    def test_simple_transform(self):
+        old_data = copy.deepcopy(self.point_cloud_in.data)  # deepcopy is not required here because we have a str
+        point_cloud_transformed = tf2_sensor_msgs.do_transform_cloud(self.point_cloud_in, self.transform_translate_xyz_300)
+
+        k = 300
+        expected_coordinates = [(1+k, 2+k, 0+k), (10+k, 20+k, 30+k)]
+        new_points = list(point_cloud2.read_points(point_cloud_transformed))
+        print("new_points are %s" % new_points)
+        assert(expected_coordinates == new_points)
+        assert(old_data == self.point_cloud_in.data)  # checking no modification in input cloud

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-import roslib
 
-import sys
 import unittest
 import struct
 import tf2_sensor_msgs
@@ -9,7 +7,6 @@ from sensor_msgs import point_cloud2
 from sensor_msgs.msg import PointField
 from tf2_ros import TransformStamped
 import copy
-import rospy
 
 ## A sample python unit test
 class PointCloudConversions(unittest.TestCase):
@@ -38,7 +35,7 @@ class PointCloudConversions(unittest.TestCase):
         assert(list(point_cloud2.read_points(self.point_cloud_in)) == [(1.0, 2.0, 0.0), (10.0, 20.0, 30.0)])
 
     def test_simple_transform(self):
-        old_data = copy.deepcopy(self.point_cloud_in.data)  # deepcopy is not required here because we have a str
+        old_data = copy.deepcopy(self.point_cloud_in.data)  # deepcopy is not required here because we have a str for now
         point_cloud_transformed = tf2_sensor_msgs.do_transform_cloud(self.point_cloud_in, self.transform_translate_xyz_300)
 
         k = 300
@@ -47,3 +44,8 @@ class PointCloudConversions(unittest.TestCase):
         print("new_points are %s" % new_points)
         assert(expected_coordinates == new_points)
         assert(old_data == self.point_cloud_in.data)  # checking no modification in input cloud
+
+if __name__ == '__main__':
+    import rosunit
+    rosunit.unitrun("test_tf2_sensor_msgs", "test_point_cloud_conversion", PointCloudConversions)
+


### PR DESCRIPTION
The previous code was not used at all, there was a mistake in the **init**.py : tf2_geometry_msgs was imported not tf2_sensor_msgs so the do_transform_cloud was not available to the python users.

The python code need some little corrections too: 
- there is no method named read_cloud but it's read_points
- as we are in python we can't use the same trick as in c++ because we got an immutable when using read_points

I also added a simple test for the point_cloud python version too.
