### PR TITLE
remove the use of slashes from topics

### DIFF
--- a/tf2_ros/src/static_transform_broadcaster.cpp
+++ b/tf2_ros/src/static_transform_broadcaster.cpp
@@ -43,7 +43,7 @@ StaticTransformBroadcaster::StaticTransformBroadcaster()
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
   // TODO(tfoote) latched equivalent
-  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf_static", custom_qos_profile);
+  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("tf_static", custom_qos_profile);
 };
 
 void StaticTransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)

--- a/tf2_ros/src/tf2_monitor.cpp
+++ b/tf2_ros/src/tf2_monitor.cpp
@@ -158,9 +158,9 @@ public:
     custom_qos_profile.depth = 100;
     
     std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TFMonitor::callback, this, std::placeholders::_1);
-    subscriber_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
+    subscriber_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf", standard_callback, custom_qos_profile);
     std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TFMonitor::callback, this, std::placeholders::_1);
-    subscriber_tf_message_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
+    subscriber_tf_message_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf_static", static_callback, custom_qos_profile);
 
     // subscriber_tf_ = node_->create_subscriber.subscribe<tf::tfMessage>("tf", 100, boost::bind(&TFMonitor::callback, this, _1));
     // subscriber_tf_message_ = node_.subscribe<tf::tfMessage>("tf_message", 100, boost::bind(&TFMonitor::callback, this, _1));

--- a/tf2_ros/src/tf2_ros/transform_broadcaster.py
+++ b/tf2_ros/src/tf2_ros/transform_broadcaster.py
@@ -37,11 +37,11 @@ from geometry_msgs.msg import TransformStamped
 
 class TransformBroadcaster:
     """
-    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"/tf"`` message topic.
+    :class:`TransformBroadcaster` is a convenient way to send transformation updates on the ``"tf"`` message topic.
     """
 
     def __init__(self):
-        self.pub_tf = rospy.Publisher("/tf", TFMessage, queue_size=100)
+        self.pub_tf = rospy.Publisher("tf", TFMessage, queue_size=100)
 
     def sendTransform(self, transform):
         if not isinstance(transform, list):

--- a/tf2_ros/src/tf2_ros/transform_listener.py
+++ b/tf2_ros/src/tf2_ros/transform_listener.py
@@ -49,8 +49,8 @@ class TransformListenerThread(threading.Thread):
 
 
     def run(self):
-        rospy.Subscriber("/tf", TFMessage, self.callback)
-        rospy.Subscriber("/tf_static", TFMessage, self.static_callback)
+        rospy.Subscriber("tf", TFMessage, self.callback)
+        rospy.Subscriber("tf_static", TFMessage, self.static_callback)
         rospy.spin()
 
     def callback(self, data):

--- a/tf2_ros/src/transform_broadcaster.cpp
+++ b/tf2_ros/src/transform_broadcaster.cpp
@@ -41,7 +41,7 @@ TransformBroadcaster::TransformBroadcaster()
 {
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
-  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("/tf_static", custom_qos_profile);
+  publisher_ = node_->create_publisher<tf2_msgs::msg::TFMessage>("tf_static", custom_qos_profile);
 };
 
 void TransformBroadcaster::sendTransform(const geometry_msgs::msg::TransformStamped & msgtf)

--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -81,9 +81,9 @@ void TransformListener::init()
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
   custom_qos_profile.depth = 100;
   std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> standard_callback = std::bind(&TransformListener::subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf", standard_callback, custom_qos_profile);
+  message_subscription_tf_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf", standard_callback, custom_qos_profile);
   std::function<void(const tf2_msgs::msg::TFMessage::SharedPtr)> static_callback = std::bind(&TransformListener::static_subscription_callback, this, std::placeholders::_1);
-  message_subscription_tf_static_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("/tf_static", static_callback, custom_qos_profile);
+  message_subscription_tf_static_ = node_->create_subscription<tf2_msgs::msg::TFMessage>("tf_static", static_callback, custom_qos_profile);
 }
 
 void TransformListener::initThread()


### PR DESCRIPTION
DDS does not support slashes. 

We have held back on developing our integrated naming design with the potential to alias ROS topics and DDS topic names. 
