### PR TITLE
Remove LGPL from license tags

### DIFF
--- a/geometry_experimental/package.xml
+++ b/geometry_experimental/package.xml
@@ -9,7 +9,6 @@
   <author>Wim Meeussen</author>
   <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
   <license>BSD</license>
-  <license>LGPL</license>
 
   <url type="website">http://www.ros.org/wiki/geometry_experimental</url>
     

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -8,7 +8,6 @@
   <author>Eitan Marder-Eppstein</author>
   <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
   <license>BSD</license>
-  <license>LGPL</license>
 
   <url type="website">http://www.ros.org/wiki/geometry_experimental</url>
     


### PR DESCRIPTION
LGPL was erroneously included in 2a38724. As there are no files with it
in the package, let's remove the tag as well.
