### PR TITLE
Added eigenTotransform function

### DIFF
--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -44,6 +44,23 @@ Eigen::Affine3d transformToEigen(const geometry_msgs::TransformStamped& t) {
 					      t.transform.rotation.x, t.transform.rotation.y, t.transform.rotation.z));
 }
 
+inline
+geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
+{
+  geometry_msgs::TransformStamped t;
+  t.transform.translation.x = T.translation().x();
+  t.transform.translation.y = T.translation().y();
+  t.transform.translation.z = T.translation().z();
+
+  Eigen::Quaterniond q(T.rotation());
+  t.transform.rotation.x = q.x();
+  t.transform.rotation.y = q.y();
+  t.transform.rotation.z = q.z();
+  t.transform.rotation.w = q.w();
+  
+  return t;
+}
+
 
 // this method needs to be implemented by client library developers
 template <>

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -37,7 +37,8 @@
 
 namespace tf2
 {
-    
+
+inline    
 Eigen::Affine3d transformToEigen(const geometry_msgs::TransformStamped& t) {
   return Eigen::Affine3d(Eigen::Translation3d(t.transform.translation.x, t.transform.translation.y, t.transform.translation.z)
 			 * Eigen::Quaterniond(t.transform.rotation.w, 
@@ -64,6 +65,7 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
 
 // this method needs to be implemented by client library developers
 template <>
+inline
 void doTransform(const tf2::Stamped<Eigen::Vector3d>& t_in, 
 		 tf2::Stamped<Eigen::Vector3d>& t_out,
 		 const geometry_msgs::TransformStamped& transform) {
@@ -73,6 +75,7 @@ void doTransform(const tf2::Stamped<Eigen::Vector3d>& t_in,
 }
 
 //convert to vector message
+inline
 geometry_msgs::PointStamped toMsg(const tf2::Stamped<Eigen::Vector3d>& in)
 {
   geometry_msgs::PointStamped msg;
@@ -84,6 +87,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<Eigen::Vector3d>& in)
   return msg;
 }
 
+inline
 void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3d>& out) {
   out.stamp_ = msg.header.stamp;
   out.frame_id_ = msg.header.frame_id;
@@ -95,6 +99,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
 
 // this method needs to be implemented by client library developers
 template <>
+inline
 void doTransform(const tf2::Stamped<Eigen::Affine3d>& t_in,
 		 tf2::Stamped<Eigen::Affine3d>& t_out,
 		 const geometry_msgs::TransformStamped& transform) {
@@ -102,6 +107,7 @@ void doTransform(const tf2::Stamped<Eigen::Affine3d>& t_in,
 }
 
 //convert to pose message
+inline
 geometry_msgs::PoseStamped toMsg(const tf2::Stamped<Eigen::Affine3d>& in)
 {
   geometry_msgs::PoseStamped msg;
@@ -117,6 +123,7 @@ geometry_msgs::PoseStamped toMsg(const tf2::Stamped<Eigen::Affine3d>& in)
   return msg;
 }
 
+inline
 void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Affine3d>& out)
 {
   out.stamp_ = msg.header.stamp;

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -48,7 +48,31 @@ TEST(TfEigen, ConvertVector)
   tf2::convert(v1, v2);
 
   EXPECT_EQ(v, v2);
-  EXPECT_EQ(v1, v2);
+  EXPECT_EQ(v1, v2);  
+  
+}
+
+TEST(TfEigen, ConvertPose)
+{
+  Eigen::Matrix4d tm;
+  
+  double alpha = M_PI/4.0;
+  double theta = M_PI/6.0;
+  double gamma = M_PI/12.0;
+  
+  tm << cos(theta)*cos(gamma),-cos(theta)*sin(gamma),sin(theta), 1, //
+  cos(alpha)*sin(gamma)+sin(alpha)*sin(theta)*cos(gamma),cos(alpha)*cos(gamma)-sin(alpha)*sin(theta)*sin(gamma),-sin(alpha)*cos(theta), 2, //
+  sin(alpha)*sin(gamma)-cos(alpha)*sin(theta)*cos(gamma),cos(alpha)*sin(theta)*sin(gamma)+sin(alpha)*cos(gamma),cos(alpha)*cos(theta), 3, //
+  0, 0, 0, 1;
+  
+  Eigen::Affine3d T(tm);
+  
+  geometry_msgs::TransformStamped msg = tf2::eigenToTransform(T);
+  Eigen::Affine3d Tback = tf2::transformToEigen(msg);
+  
+  EXPECT_TRUE(T.isApprox(Tback));
+  EXPECT_TRUE(tm.isApprox(Tback.matrix()));
+    
 }
 
 


### PR DESCRIPTION
There was no eigenToTransform function as the equivalent kdlToTransform tf2_kdl.

The function does not fill the transform information (child frame and header information), as the kdl equivalent does.

should be interesting to add to the signature of the function the missing information needed to get a complete TransformStamped message
