### PR TITLE
Only set c++11 flag for C++

### DIFF
--- a/tf2_msgs/CMakeLists.txt
+++ b/tf2_msgs/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(tf2_msgs)
 
 if(NOT WIN32)
-  add_definitions(-std=c++11)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 endif()
 
 find_package(ament_cmake)


### PR DESCRIPTION
Otherwise this will fail with C code (such as the Python extension) on OSX:

http://ci.ros2.org/job/ci_osx/766/console
