### PR TITLE
cleanup for windows warnings

### DIFF
--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -56,14 +56,12 @@ namespace tf2
     return durationToSec(Duration(timepoint.time_since_epoch()));
   }
 
-  // Display functions as there is no default display
-  // TODO: find a proper way to handle display
   inline std::string displayTimePoint(const TimePoint& stamp)
   {
-    // Below would only work with GCC 5.0 and above
-    //return std::put_time(&stamp, "%c");
     std::time_t time = std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::milliseconds>(stamp));
-    return std::ctime(&time);
+    char str[100];
+    std::strftime(str, sizeof(str), "%c", std::localtime(&time));
+    return std::string(str);
   }
 
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -417,8 +417,8 @@ tf2::TF2Error BufferCore::walkToTopParent(F& f, TimePoint time, CompactFrameID t
   if (frame_chain)
   {
     // Pruning: Compare the chains starting at the parent (end) until they differ
-    int m = reverse_frame_chain.size()-1;
-    int n = frame_chain->size()-1;
+    int m = (int)reverse_frame_chain.size()-1;
+    int n = (int)frame_chain->size()-1;
     for (; m >= 0 && n >= 0; --m, --n)
     {
       if ((*frame_chain)[n] != reverse_frame_chain[m])
@@ -538,8 +538,8 @@ geometry_msgs::msg::TransformStamped
   msg.transform.rotation.z = transform.getRotation().z();
   msg.transform.rotation.w = transform.getRotation().w();
   std::chrono::time_point_cast<std::chrono::seconds>(time_out);
-  msg.header.stamp.sec = std::chrono::time_point_cast<std::chrono::seconds>(time_out).time_since_epoch().count();
-  msg.header.stamp.nanosec = std::chrono::time_point_cast<std::chrono::nanoseconds>(time_out).time_since_epoch().count() - msg.header.stamp.sec;
+  msg.header.stamp.sec = (uint32_t)std::chrono::time_point_cast<std::chrono::seconds>(time_out).time_since_epoch().count();
+  msg.header.stamp.nanosec = (uint32_t)std::chrono::time_point_cast<std::chrono::nanoseconds>(time_out).time_since_epoch().count() - msg.header.stamp.sec;
   msg.header.frame_id = target_frame;
   msg.child_frame_id = source_frame;
 
@@ -563,8 +563,8 @@ geometry_msgs::msg::TransformStamped
   msg.transform.rotation.y = transform.getRotation().y();
   msg.transform.rotation.z = transform.getRotation().z();
   msg.transform.rotation.w = transform.getRotation().w();
-  msg.header.stamp.sec = std::chrono::time_point_cast<std::chrono::seconds>(time_out).time_since_epoch().count();
-  msg.header.stamp.nanosec = std::chrono::time_point_cast<std::chrono::nanoseconds>(time_out).time_since_epoch().count() - msg.header.stamp.sec;
+  msg.header.stamp.sec = (uint32_t)std::chrono::time_point_cast<std::chrono::seconds>(time_out).time_since_epoch().count();
+  msg.header.stamp.nanosec = (uint32_t)std::chrono::time_point_cast<std::chrono::nanoseconds>(time_out).time_since_epoch().count() - msg.header.stamp.sec;
   msg.header.frame_id = target_frame;
   msg.child_frame_id = source_frame;
 
@@ -1236,7 +1236,7 @@ TransformableRequestHandle BufferCore::addTransformableRequest(TransformableCall
 struct BufferCore::RemoveRequestByID
 {
   RemoveRequestByID(TransformableRequestHandle handle)
-  : handle_(handle)
+  : handle_((TransformableCallbackHandle)handle)
   {}
 
   bool operator()(const TransformableRequest& req)
@@ -1264,7 +1264,7 @@ void BufferCore::cancelTransformableRequest(TransformableRequestHandle handle)
 bool BufferCore::_frameExists(const std::string& frame_id_str) const
 {
   std::unique_lock<std::mutex> lock(frame_mutex_);
-  return frameIDs_.count(frame_id_str);
+  return frameIDs_.count(frame_id_str) != 0;
 }
 
 bool BufferCore::_getParent(const std::string& frame_id, TimePoint time, std::string& parent) const
@@ -1519,8 +1519,8 @@ void BufferCore::_chainAsVector(const std::string & target_frame, TimePoint targ
         assert(0);
       }
     }
-    int m = target_frame_chain.size()-1;
-    int n = source_frame_chain.size()-1;
+    int m = (int)target_frame_chain.size()-1;
+    int n = (int)source_frame_chain.size()-1;
     for (; m >= 0 && n >= 0; --m, --n)
     {
       if (source_frame_chain[n] != target_frame_chain[m])
@@ -1532,7 +1532,7 @@ void BufferCore::_chainAsVector(const std::string & target_frame, TimePoint targ
 
     if (m < target_frame_chain.size())
     {
-      for (unsigned int i = 0; i <= m; ++i)
+      for (int i = 0; i <= m; ++i)
       {
         source_frame_chain.push_back(target_frame_chain[i]);
       }

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -264,7 +264,7 @@ void TimeCache::clearList()
 
 unsigned int TimeCache::getListLength()
 {
-  return storage_.size();
+  return (unsigned int)storage_.size();
 }
 
 P_TimeAndFrameID TimeCache::getLatestTimeAndParent()

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -42,7 +42,7 @@ void seed_rand()
   values.clear();
   for (unsigned int i = 0; i < 2000; i++)
   {
-    int pseudo_rand = std::floor(i * 3.141592653589793);
+    int pseudo_rand = (int)std::floor((double)i * 3.141592653589793);
     values.push_back(( pseudo_rand % 100)/50.0 - 1.0);
     //printf("Seeding with %f\n", values.back());
   }
@@ -79,7 +79,7 @@ TEST(TimeCache, Repeatability)
   
   for ( uint64_t i = 1; i < runs ; i++ )
   {
-    stor.frame_id_ = i;
+    stor.frame_id_ = tf2::CompactFrameID(i);
     stor.stamp_ = TimePoint(std::chrono::nanoseconds(i));
     
     cache.insertData(stor);
@@ -132,13 +132,13 @@ TEST(TimeCache, ZeroAtFront)
   
   for ( uint64_t i = 1; i < runs ; i++ )
   {
-    stor.frame_id_ = i;
+    stor.frame_id_ = tf2::CompactFrameID(i);
     stor.stamp_ = TimePoint(std::chrono::nanoseconds(i));
     
     cache.insertData(stor);
   }
 
-  stor.frame_id_ = runs;
+  stor.frame_id_ = tf2::CompactFrameID(runs);
   stor.stamp_ = TimePoint(std::chrono::nanoseconds(runs));
   cache.insertData(stor);
 
@@ -154,7 +154,7 @@ TEST(TimeCache, ZeroAtFront)
   EXPECT_EQ(stor.frame_id_, runs);
   EXPECT_EQ(stor.stamp_, TimePoint(std::chrono::nanoseconds(runs)));
 
-  stor.frame_id_ = runs;
+  stor.frame_id_ = tf2::CompactFrameID(runs);
   stor.stamp_ = TimePoint(std::chrono::nanoseconds(runs+1));
   cache.insertData(stor);
 
@@ -242,7 +242,7 @@ TEST(TimeCache, ReparentingInterpolationProtection)
     zvalues[step] = 10.0 * get_rand();
 
     stor.translation_.setValue(xvalues[step], yvalues[step], zvalues[step]);
-    stor.frame_id_ = step + 4;
+    stor.frame_id_ = tf2::CompactFrameID(step + 4);
     stor.stamp_ = TimePoint(std::chrono::nanoseconds(step * 100 + offset));
     cache.insertData(stor);
   }

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -38,7 +38,7 @@ typedef std::chrono::system_clock::time_point TimePoint;
 void seed_rand()
 {
   //Seed random number generator with current microseond count
-  srand(std::chrono::system_clock::now().time_since_epoch().count());
+  srand((unsigned int)std::chrono::system_clock::now().time_since_epoch().count());
 };
 
 void generate_rand_vectors(double scale, uint64_t runs, std::vector<double>& xvalues, std::vector<double>& yvalues, std::vector<double>&zvalues)


### PR DESCRIPTION
This cleans up most warnings for tf2. 

The ctime fix is not quite working but I want to get this in for now and can return to that later. I think it needs the `#define` and explicit include here: http://en.cppreference.com/w/c/chrono/ctime

CI: http://ci.ros2.org/job/ci_windows/1021/
