### PR TITLE
Get rid of date/time formatting, just use double.

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -14,7 +14,7 @@ include_directories(include src/bt ${geometry_msgs_INCLUDE_DIRS} ${console_bridg
 # export user definitions
 
 #CPP Libraries
-add_library(tf2 src/cache.cpp src/buffer_core.cpp src/static_cache.cpp)
+add_library(tf2 src/cache.cpp src/buffer_core.cpp src/static_cache.cpp src/time.cpp)
 target_link_libraries(tf2 ${geometry_msgs_LIBRARIES} ${console_bridge_LIBRARIES})
 
 install(TARGETS tf2
@@ -33,17 +33,17 @@ if(AMENT_ENABLE_TESTING)
   # find_package(ament_lint_auto REQUIRED)
   # ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest)
-     
+
   ament_add_gtest(test_cache_unittest test/cache_unittest.cpp)
   if(TARGET test_cache_unittest)
     target_link_libraries(test_cache_unittest tf2 ${geometry_msgs_LIBRARIES} ${console_bridge_LIBRARIES})
   endif()
-  
+
   ament_add_gtest(test_static_cache_unittest test/static_cache_test.cpp)
   if(TARGET test_static_cache_unittest)
     target_link_libraries(test_static_cache_unittest tf2 ${geometry_msgs_LIBRARIES} ${console_bridge_LIBRARIES})
   endif()
-  
+
   ament_add_gtest(test_simple test/simple_tf2_core.cpp)
   if(TARGET test_simple)
     target_link_libraries(test_simple tf2  ${geometry_msgs_LIBRARIES} ${console_bridge_LIBRARIES})

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Open Source Robotics Foundation, Inc.
+ * Copyright (c) 2015-2016, Open Source Robotics Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,8 +31,10 @@
  #define TF2_TIME_H
 
 #include <chrono>
+#include <new>
 #include <stdio.h>
 #include <string>
+#include <string.h>
 #include <thread>
 
 namespace tf2
@@ -64,12 +66,18 @@ namespace tf2
     const char * format_str = "%.6f";
     double current_time = timeToSec(stamp);
     int buff_size = snprintf(NULL, 0, format_str, current_time);
+    if (buff_size < 0) {
+      throw std::runtime_error(strerror(errno));
+    }
     char * buffer = new char[buff_size];
-    snprintf(buffer, buff_size, format_str, current_time);
+    int bytes_written = snprintf(buffer, buff_size, format_str, current_time);
+    if (bytes_written < 0) {
+      throw std::runtime_error(strerror(errno));
+    }
     std::string result = std::string(buffer);
     delete[] buffer;
     return result;
   }
 }
 
-#endif // TF2_TIME_CACHE_H
+#endif // TF2_TIME_H

--- a/tf2/include/tf2/time.h
+++ b/tf2/include/tf2/time.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Open Source Robotics Foundation, Inc.
+ * Copyright (c) 2015, 2016, Open Source Robotics Foundation, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+ #ifndef TF2_TIME_H
+ #define TF2_TIME_H
+
 #include <chrono>
-#include <iomanip>
-#include <ctime>
+#include <stdio.h>
+#include <string>
 #include <thread>
 
 namespace tf2
@@ -50,7 +53,7 @@ namespace tf2
   inline double durationToSec(const tf2::Duration & input){
     return (double)std::chrono::duration_cast<std::chrono::seconds>(input).count();
   }
-  
+
   inline double timeToSec(const TimePoint& timepoint)
   {
     return durationToSec(Duration(timepoint.time_since_epoch()));
@@ -58,11 +61,15 @@ namespace tf2
 
   inline std::string displayTimePoint(const TimePoint& stamp)
   {
-    std::time_t time = std::chrono::system_clock::to_time_t(std::chrono::time_point_cast<std::chrono::milliseconds>(stamp));
-    char str[100];
-    std::strftime(str, sizeof(str), "%c", std::localtime(&time));
-    return std::string(str);
+    const char * format_str = "%.6f";
+    double current_time = timeToSec(stamp);
+    int buff_size = snprintf(NULL, 0, format_str, current_time);
+    char * buffer = new char[buff_size];
+    snprintf(buffer, buff_size, format_str, current_time);
+    std::string result = std::string(buffer);
+    delete[] buffer;
+    return result;
   }
-
-
 }
+
+#endif // TF2_TIME_CACHE_H

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -45,9 +45,10 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
   int buff_size = snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
 #ifdef _WIN32
-    size_t errmsglen = strerrorlen_s(errno) + 1;
-    char errmsg[errmsglen];
-    strerror_s(errmsg, errmsglen, errno);
+    // Using fixed buffer size since, strerrorlen_s not yet available
+    const int errormsglen = 200;
+    char errmsg[errormsglen];
+    strerror_s(errmsg, errormsglen, errno);
     throw std::runtime_error(errmsg);
 #else
     throw std::runtime_error(strerror(errno));
@@ -58,9 +59,10 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
   int bytes_written = snprintf(buffer, buff_size, format_str, current_time);
   if (bytes_written < 0) {
 #ifdef _WIN32
-    size_t errmsglen = strerrorlen_s(errno) + 1;
-    char errmsg[errmsglen];
-    strerror_s(errmsg, errmsglen, errno);
+    // Using fixed buffer size since, strerrorlen_s not yet available
+    const int errormsglen = 200;
+    char errmsg[errormsglen];
+    strerror_s(errmsg, errormsglen, errno);
     throw std::runtime_error(errmsg);
 #else
     throw std::runtime_error(strerror(errno));

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -35,6 +35,7 @@
 
 #include <errno.h>
 #include <string.h>
+#include <stdio.h>
 
 
 #include "tf2/time.h"
@@ -45,12 +46,12 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
 {
   const char * format_str = "%.6f";
   double current_time = timeToSec(stamp);
-#ifdef __STDC_LIB_EXT1__
+#ifdef _WIN32
   int buff_size = snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
-    size_t errmsglen = strerrorlen_s(errno) + 1;
+    size_t errmsglen = strerrorlen_r(errno) + 1;
     char errmsg[errmsglen];
-    strerror_rq(errmsg, errmsglen, errno);
+    strerror_r(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
   }
   char buffer[buff_size];
@@ -71,7 +72,7 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
   if (buff_size < 0) {
     throw std::runtime_error(strerror(errno));
   }
-#endif //__STDC_LIB_EXT1__
+#endif // _WIN32
   std::string result = std::string(buffer);
   return result;
 }

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -29,14 +29,10 @@
 
 /** \author Tully Foote */
 
-// #define __STDC_WANT_LIB_EXT1__ 1
-// // Needs to be first with above define
-#include <time.h>
-
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
-
+#include <time.h>
 
 #include "tf2/time.h"
 

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -46,33 +46,30 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
 {
   const char * format_str = "%.6f";
   double current_time = timeToSec(stamp);
-#ifdef _WIN32
   int buff_size = snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
+#ifdef __STDC_LIB_EXT1__
     size_t errmsglen = strerrorlen_s(errno) + 1;
     char errmsg[errmsglen];
     strerror_s(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
-  }
+#else
+    throw std::runtime_error(strerror(errno));
+#endif // __STDC_LIB_EXT1__
+}
+
   char buffer[buff_size];
   int bytes_written = snprintf(buffer, buff_size, format_str, current_time);
   if (bytes_written < 0) {
+#ifdef __STDC_LIB_EXT1__
     size_t errmsglen = strerrorlen_s(errno) + 1;
     char errmsg[errmsglen];
     strerror_s(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
-  }
 #else
-  int buff_size = snprintf(NULL, 0, format_str, current_time);
-  if (buff_size < 0) {
     throw std::runtime_error(strerror(errno));
+#endif // __STDC_LIB_EXT1__
   }
-  char buffer[buff_size];
-  int bytes_written = snprintf(buffer, buff_size, format_str, current_time);
-  if (buff_size < 0) {
-    throw std::runtime_error(strerror(errno));
-  }
-#endif // _WIN32
   std::string result = std::string(buffer);
   return result;
 }

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -29,8 +29,8 @@
 
 /** \author Tully Foote */
 
-#define __STDC_WANT_LIB_EXT1__ 1
-// Needs to be first with above define
+// #define __STDC_WANT_LIB_EXT1__ 1
+// // Needs to be first with above define
 #include <time.h>
 
 #include <errno.h>
@@ -48,28 +48,29 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
   double current_time = timeToSec(stamp);
   int buff_size = snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
-#ifdef __STDC_LIB_EXT1__
+#ifdef _WIN32
     size_t errmsglen = strerrorlen_s(errno) + 1;
     char errmsg[errmsglen];
     strerror_s(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
 #else
     throw std::runtime_error(strerror(errno));
-#endif // __STDC_LIB_EXT1__
+#endif // _WIN32
 }
 
-  char buffer[buff_size];
+  char * buffer = new char[buff_size];
   int bytes_written = snprintf(buffer, buff_size, format_str, current_time);
   if (bytes_written < 0) {
-#ifdef __STDC_LIB_EXT1__
+#ifdef _WIN32
     size_t errmsglen = strerrorlen_s(errno) + 1;
     char errmsg[errmsglen];
     strerror_s(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
 #else
     throw std::runtime_error(strerror(errno));
-#endif // __STDC_LIB_EXT1__
+#endif // _WIN32
   }
   std::string result = std::string(buffer);
+  delete[] buffer;
   return result;
 }

--- a/tf2/src/time.cpp
+++ b/tf2/src/time.cpp
@@ -49,9 +49,9 @@ std::string tf2::displayTimePoint(const TimePoint& stamp)
 #ifdef _WIN32
   int buff_size = snprintf(NULL, 0, format_str, current_time);
   if (buff_size < 0) {
-    size_t errmsglen = strerrorlen_r(errno) + 1;
+    size_t errmsglen = strerrorlen_s(errno) + 1;
     char errmsg[errmsglen];
-    strerror_r(errmsg, errmsglen, errno);
+    strerror_s(errmsg, errmsglen, errno);
     throw std::runtime_error(errmsg);
   }
   char buffer[buff_size];

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -32,6 +32,7 @@
 #include <tf2/buffer_core.h>
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"
+#include "tf2/time.h"
 
 typedef std::chrono::system_clock::time_point TimePoint;
 
@@ -135,6 +136,13 @@ TEST(tf2_canTransform, One_Exists)
   st.transform.rotation.w = 1;
   EXPECT_TRUE(tfc.setTransform(st, "authority1"));
   EXPECT_FALSE(tfc.canTransform("foo", "bar", TimePoint(std::chrono::seconds(1))));
+}
+
+TEST(tf2_time, Display_Time_Point)
+{
+  tf2::TimePoint t = tf2::get_now();
+  // Check ability to stringify
+  std::string s = tf2::displayTimePoint(t);
 }
 
 


### PR DESCRIPTION
This will make better sense when using sim time anyway.

Fixes #136 

CI: 
http://ci.ros2.org/job/ci_linux/997
http://ci.ros2.org/job/ci_osx/828
http://ci.ros2.org/job/ci_windows/1077
