### PR TITLE
Fix comment on BufferCore::MAX_GRAPH_DEPTH.

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -90,7 +90,7 @@ class BufferCore
 public:
   /************* Constants ***********************/
   static const int DEFAULT_CACHE_TIME = 10;  //!< The default amount of time to cache data in seconds
-  static const uint32_t MAX_GRAPH_DEPTH = 1000UL;  //!< The default amount of time to cache data in seconds
+  static const uint32_t MAX_GRAPH_DEPTH = 1000UL;  //!< Maximum graph search depth (deeper graphs will be assumed to have loops)
 
   /** Constructor
    * \param interpolating Whether to interpolate, if this is false the closest value will be returned


### PR DESCRIPTION
Noticed it while following the link to `buffer_core.h` via [Is there a max number of edges allowed between two frames in a TF tree?](http://answers.ros.org/question/229902/is-there-a-max-number-of-edges-allowed-between-two-frames-in-a-tf-tree/) on ROS Answers.
