### PR TITLE
Make tf2_py compatible with python3.

### DIFF
--- a/tf2_py/src/python_compat.h
+++ b/tf2_py/src/python_compat.h
@@ -43,4 +43,11 @@ inline PyObject *pythonImport(const std::string & name)
   return module;
 }
 
+inline PyObject *pythonBorrowAttrString(PyObject* o, const char *name)
+{
+    PyObject *r = PyObject_GetAttrString(o, name);
+    Py_XDECREF(r);
+    return r;
+}
+
 #endif

--- a/tf2_py/src/python_compat.h
+++ b/tf2_py/src/python_compat.h
@@ -1,0 +1,46 @@
+#ifndef TF2_PY_PYTHON_COMPAT_H
+#define TF2_PY_PYTHON_COMPAT_H
+
+#include <Python.h>
+
+#include <string>
+
+inline PyObject *stringToPython(const std::string &input)
+{
+#if PY_MAJOR_VERSION >= 3
+  return PyUnicode_FromStringAndSize(input.c_str(), input.size());
+#else
+  return PyString_FromStringAndSize(input.c_str(), input.size());
+#endif
+}
+
+inline PyObject *stringToPython(const char *input)
+{
+#if PY_MAJOR_VERSION >= 3
+  return PyUnicode_FromString(input);
+#else
+  return PyString_FromString(input);
+#endif
+}
+
+inline std::string stringFromPython(PyObject * input)
+{
+  Py_ssize_t size;
+  char * data;
+#if PY_MAJOR_VERSION >= 3
+  data = PyUnicode_AsUTF8AndSize(input, &size);
+#else
+  PyString_AsStringAndSize(input, &data, &size);
+#endif
+  return std::string(data, size);
+}
+
+inline PyObject *pythonImport(const std::string & name)
+{
+  PyObject *py_name = stringToPython(name);
+  PyObject *module  = PyImport_Import(py_name);
+  Py_XDECREF(py_name);
+  return module;
+}
+
+#endif

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -58,9 +58,13 @@ struct buffer_core_t {
 
 
 static PyTypeObject buffer_core_Type = {
-  PyObject_HEAD_INIT(&PyType_Type)
+#if PY_MAJOR_VERSION < 3
+  PyObject_HEAD_INIT(NULL)
   0,                               /*size*/
-  "_tf2.BufferCore",                /*name*/
+# else
+  PyVarObject_HEAD_INIT(NULL, 0)
+#endif
+  "_tf2.BufferCore",               /*name*/
   sizeof(buffer_core_t),           /*basicsize*/
 };
 

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -68,13 +68,6 @@ static PyTypeObject buffer_core_Type = {
   sizeof(buffer_core_t),           /*basicsize*/
 };
 
-static PyObject *PyObject_BorrowAttrString(PyObject* o, const char *name)
-{
-    PyObject *r = PyObject_GetAttrString(o, name);
-    Py_XDECREF(r);
-    return r;
-}
-
 static PyObject *transform_converter(const geometry_msgs::TransformStamped* transform)
 {
   PyObject *pclass, *pargs, *pinst = NULL;
@@ -390,22 +383,22 @@ static PyObject *setTransform(PyObject *self, PyObject *args)
     return NULL;
 
   geometry_msgs::TransformStamped transform;
-  PyObject *header = PyObject_BorrowAttrString(py_transform, "header");
-  transform.child_frame_id = stringFromPython(PyObject_BorrowAttrString(py_transform, "child_frame_id"));
-  transform.header.frame_id = stringFromPython(PyObject_BorrowAttrString(header, "frame_id"));
-  if (rostime_converter(PyObject_BorrowAttrString(header, "stamp"), &transform.header.stamp) != 1)
+  PyObject *header = pythonBorrowAttrString(py_transform, "header");
+  transform.child_frame_id = stringFromPython(pythonBorrowAttrString(py_transform, "child_frame_id"));
+  transform.header.frame_id = stringFromPython(pythonBorrowAttrString(header, "frame_id"));
+  if (rostime_converter(pythonBorrowAttrString(header, "stamp"), &transform.header.stamp) != 1)
     return NULL;
 
-  PyObject *mtransform = PyObject_BorrowAttrString(py_transform, "transform");
-  PyObject *translation = PyObject_BorrowAttrString(mtransform, "translation");
-  transform.transform.translation.x = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "x"));
-  transform.transform.translation.y = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "y"));
-  transform.transform.translation.z = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "z"));
-  PyObject *rotation = PyObject_BorrowAttrString(mtransform, "rotation");
-  transform.transform.rotation.x = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "x"));
-  transform.transform.rotation.y = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "y"));
-  transform.transform.rotation.z = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "z"));
-  transform.transform.rotation.w = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "w"));
+  PyObject *mtransform = pythonBorrowAttrString(py_transform, "transform");
+  PyObject *translation = pythonBorrowAttrString(mtransform, "translation");
+  transform.transform.translation.x = PyFloat_AsDouble(pythonBorrowAttrString(translation, "x"));
+  transform.transform.translation.y = PyFloat_AsDouble(pythonBorrowAttrString(translation, "y"));
+  transform.transform.translation.z = PyFloat_AsDouble(pythonBorrowAttrString(translation, "z"));
+  PyObject *rotation = pythonBorrowAttrString(mtransform, "rotation");
+  transform.transform.rotation.x = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "x"));
+  transform.transform.rotation.y = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "y"));
+  transform.transform.rotation.z = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "z"));
+  transform.transform.rotation.w = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "w"));
 
   bc->setTransform(transform, authority);
   Py_RETURN_NONE;
@@ -421,22 +414,22 @@ static PyObject *setTransformStatic(PyObject *self, PyObject *args)
     return NULL;
 
   geometry_msgs::TransformStamped transform;
-  PyObject *header = PyObject_BorrowAttrString(py_transform, "header");
-  transform.child_frame_id = stringFromPython(PyObject_BorrowAttrString(py_transform, "child_frame_id"));
-  transform.header.frame_id = stringFromPython(PyObject_BorrowAttrString(header, "frame_id"));
-  if (rostime_converter(PyObject_BorrowAttrString(header, "stamp"), &transform.header.stamp) != 1)
+  PyObject *header = pythonBorrowAttrString(py_transform, "header");
+  transform.child_frame_id = stringFromPython(pythonBorrowAttrString(py_transform, "child_frame_id"));
+  transform.header.frame_id = stringFromPython(pythonBorrowAttrString(header, "frame_id"));
+  if (rostime_converter(pythonBorrowAttrString(header, "stamp"), &transform.header.stamp) != 1)
     return NULL;
 
-  PyObject *mtransform = PyObject_BorrowAttrString(py_transform, "transform");
-  PyObject *translation = PyObject_BorrowAttrString(mtransform, "translation");
-  transform.transform.translation.x = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "x"));
-  transform.transform.translation.y = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "y"));
-  transform.transform.translation.z = PyFloat_AsDouble(PyObject_BorrowAttrString(translation, "z"));
-  PyObject *rotation = PyObject_BorrowAttrString(mtransform, "rotation");
-  transform.transform.rotation.x = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "x"));
-  transform.transform.rotation.y = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "y"));
-  transform.transform.rotation.z = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "z"));
-  transform.transform.rotation.w = PyFloat_AsDouble(PyObject_BorrowAttrString(rotation, "w"));
+  PyObject *mtransform = pythonBorrowAttrString(py_transform, "transform");
+  PyObject *translation = pythonBorrowAttrString(mtransform, "translation");
+  transform.transform.translation.x = PyFloat_AsDouble(pythonBorrowAttrString(translation, "x"));
+  transform.transform.translation.y = PyFloat_AsDouble(pythonBorrowAttrString(translation, "y"));
+  transform.transform.translation.z = PyFloat_AsDouble(pythonBorrowAttrString(translation, "z"));
+  PyObject *rotation = pythonBorrowAttrString(mtransform, "rotation");
+  transform.transform.rotation.x = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "x"));
+  transform.transform.rotation.y = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "y"));
+  transform.transform.rotation.z = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "z"));
+  transform.transform.rotation.w = PyFloat_AsDouble(pythonBorrowAttrString(rotation, "w"));
 
   // only difference to above is is_static == True
   bc->setTransform(transform, authority, true);


### PR DESCRIPTION
This PR makes tf2_py compatible with python3. I compiled the package for both python 3.5 and 2.7 (which worked), but I **did not** test the resulting python module.

There were three issues to fix:
- Python3 uses unicode strings for text. The old python2 string type no longer exists.
- Module initialization has been overhauled for python3.
- Type definitions changed slightly.

I put wrapper functions for the correct string types in `python_compat.h` (and one convenience function for importing modules). Something similar could be done for the type definition and the module initialization, but those would involve writing new macros, which would not necessarily make the code easier to maintain (especially in the case of module initialization).

I did not use `py3c` (a C API compatibility layer for python2/3) to avoid adding a new dependency. If a new dependency is acceptable, `py3c` would be a good alternative. It would involve adding a new rosdep key though, I assume.

If this is the way to go, `PyObject_BorrowAttrString` could also be moved to `python_compat.h`, to group python convenience functions together. (Though I would rename it so it doesn't look like a real python function. It took me a while of digging through the python C API before realising it is defined in the source file itself).
