### PR TITLE
Adds ability to load static TF from the ROS parameter server.

### DIFF
--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -36,6 +36,7 @@
   <run_depend>tf2_msgs</run_depend>
 
   <test_depend>rosunit</test_depend>
+  <test_depend>rosbash</test_depend>
 
 </package>
 

--- a/test_tf2/test/static_publisher.launch
+++ b/test_tf2/test/static_publisher.launch
@@ -1,5 +1,33 @@
 <launch>
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub_ab" args="1 0 0 0 0 0 1 a b" />
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub_bc" args="0 1 0 0 0 0 1 b c" />
-  <test test-name="test_static_publisher" pkg="test_tf2" type="test_static_publisher" args="--text" />
+
+  <!-- Start the static tf publisher with a valid tf.  There is a test
+       (tf_from_param_server_valid) that ensures the TF is published. -->
+  <rosparam param="test_tf2/tf_valid"
+            file="$(find test_tf2)/test/test_tf_valid.yaml" />
+  <node pkg="tf2_ros" type="static_transform_publisher"
+        name="test_static_pub_param_valid"
+        args="test_tf2/tf_valid" />
+
+  <!-- Start the static tf publisher with an *invalid* tf.
+       The main purpose of this test is to ensure the node dies gracefully. -->
+  <rosparam param="test_tf2/tf_invalid"
+            file="$(find test_tf2)/test/test_tf_invalid.yaml" />
+  <node pkg="tf2_ros" type="static_transform_publisher"
+        name="test_static_pub_param_invalid"
+        args="test_tf2/tf_invalid" />
+
+  <!-- Start the static tf publisher with a non-existent parameter.
+       The main purpose of this test is to ensure the node dies gracefully. -->
+  <node pkg="tf2_ros" type="static_transform_publisher"
+        name="test_static_pub_param_null"
+        args="test_tf2/tf_null" />
+
+  <test test-name="test_static_publisher" pkg="test_tf2"
+        type="test_static_publisher" args="--text" />
+
+  <test test-name="test_static_publisher_py"
+        pkg="test_tf2"
+        type="test_static_publisher.py"/>
 </launch>

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -37,7 +37,7 @@
 
 #include "tf2_ros/transform_listener.h"
 
-TEST(StaticTranformPublsher, a_b_different_times)
+TEST(StaticTransformPublisher, a_b_different_times)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
@@ -46,7 +46,7 @@ TEST(StaticTranformPublsher, a_b_different_times)
   EXPECT_TRUE(mB.canTransform("a", "b", ros::Time(1000), ros::Duration(1.0)));
 };
 
-TEST(StaticTranformPublsher, a_c_different_times)
+TEST(StaticTransformPublisher, a_c_different_times)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
@@ -55,7 +55,7 @@ TEST(StaticTranformPublsher, a_c_different_times)
   EXPECT_TRUE(mB.canTransform("a", "c", ros::Time(1000), ros::Duration(1.0)));
 };
 
-TEST(StaticTranformPublsher, a_d_different_times)
+TEST(StaticTransformPublisher, a_d_different_times)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
@@ -80,7 +80,7 @@ TEST(StaticTranformPublsher, a_d_different_times)
   EXPECT_FALSE(mB.canTransform("a", "d", ros::Time(100), ros::Duration(0)));
 };
 
-TEST(StaticTranformPublsher, multiple_parent_test)
+TEST(StaticTransformPublisher, multiple_parent_test)
 {
   tf2_ros::Buffer mB;
   tf2_ros::TransformListener tfl(mB);
@@ -112,7 +112,7 @@ TEST(StaticTranformPublsher, multiple_parent_test)
   EXPECT_FALSE(mB.canTransform("a", "d", ros::Time(), ros::Duration(1.0)));
 };
 
-TEST(StaticTranformPublsher, tf_from_param_server_valid)
+TEST(StaticTransformPublisher, tf_from_param_server_valid)
 {
   // This TF is loaded from the parameter server; ensure it is valid.
   tf2_ros::Buffer mB;

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -37,7 +37,6 @@
 
 #include "tf2_ros/transform_listener.h"
 
-
 TEST(StaticTranformPublsher, a_b_different_times)
 {
   tf2_ros::Buffer mB;
@@ -112,6 +111,16 @@ TEST(StaticTranformPublsher, multiple_parent_test)
   EXPECT_TRUE(mB.canTransform("new_parent", "other_child2", ros::Time(), ros::Duration(1.0)));
   EXPECT_FALSE(mB.canTransform("a", "d", ros::Time(), ros::Duration(1.0)));
 };
+
+TEST(StaticTranformPublsher, tf_from_param_server_valid)
+{
+  // This TF is loaded from the parameter server; ensure it is valid.
+  tf2_ros::Buffer mB;
+  tf2_ros::TransformListener tfl(mB);
+  EXPECT_TRUE(mB.canTransform("robot_calibration", "world", ros::Time(), ros::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("robot_calibration", "world", ros::Time(100), ros::Duration(1.0)));
+  EXPECT_TRUE(mB.canTransform("robot_calibration", "world", ros::Time(1000), ros::Duration(1.0)));
+}
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -65,12 +65,11 @@ TEST(StaticTranformPublsher, a_d_different_times)
   ts.header.frame_id = "c";
   ts.header.stamp = ros::Time(10.0);
   ts.child_frame_id = "d";
-  
+
   // make sure listener has populated
   EXPECT_TRUE(mB.canTransform("a", "c", ros::Time(), ros::Duration(1.0)));
   EXPECT_TRUE(mB.canTransform("a", "c", ros::Time(100), ros::Duration(1.0)));
   EXPECT_TRUE(mB.canTransform("a", "c", ros::Time(1000), ros::Duration(1.0)));
-
 
   mB.setTransform(ts, "authority");
   //printf("%s\n", mB.allFramesAsString().c_str());
@@ -80,7 +79,6 @@ TEST(StaticTranformPublsher, a_d_different_times)
   EXPECT_FALSE(mB.canTransform("a", "d", ros::Time(1), ros::Duration(0)));
   EXPECT_TRUE(mB.canTransform("a", "d", ros::Time(10), ros::Duration(0)));
   EXPECT_FALSE(mB.canTransform("a", "d", ros::Time(100), ros::Duration(0)));
-
 };
 
 TEST(StaticTranformPublsher, multiple_parent_test)
@@ -95,12 +93,11 @@ TEST(StaticTranformPublsher, multiple_parent_test)
   ts.child_frame_id = "d";
 
   stb.sendTransform(ts);
-  
+
   // make sure listener has populated
   EXPECT_TRUE(mB.canTransform("a", "d", ros::Time(), ros::Duration(1.0)));
   EXPECT_TRUE(mB.canTransform("a", "d", ros::Time(100), ros::Duration(1.0)));
   EXPECT_TRUE(mB.canTransform("a", "d", ros::Time(1000), ros::Duration(1.0)));
-
 
   // Publish new transform with child 'd', should replace old one in static tf
   ts.header.frame_id = "new_parent";

--- a/test_tf2/test/test_static_publisher.py
+++ b/test_tf2/test/test_static_publisher.py
@@ -1,0 +1,96 @@
+#! /usr/bin/python
+#***********************************************************
+#* Software License Agreement (BSD License)
+#*
+#*  Copyright (c) 2016, Felix Duvallet
+#*  All rights reserved.
+#*
+#*  Redistribution and use in source and binary forms, with or without
+#*  modification, are permitted provided that the following conditions
+#*  are met:
+#*
+#*   * Redistributions of source code must retain the above copyright
+#*     notice, this list of conditions and the following disclaimer.
+#*   * Redistributions in binary form must reproduce the above
+#*     copyright notice, this list of conditions and the following
+#*     disclaimer in the documentation and/or other materials provided
+#*     with the distribution.
+#*   * Neither the name of Willow Garage, Inc. nor the names of its
+#*     contributors may be used to endorse or promote products derived
+#*     from this software without specific prior written permission.
+#*
+#*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+#*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+#*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+#*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+#*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+#*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+#*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+#*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#*  POSSIBILITY OF SUCH DAMAGE.
+#* 
+#* Author: Felix Duvallet
+#***********************************************************
+
+import subprocess
+import unittest
+
+import rospy
+PKG = 'test_tf2'
+import roslib; roslib.load_manifest(PKG)
+
+
+class TestStaticPublisher(unittest.TestCase):
+    """
+    These tests ensure the static transform publisher dies gracefully when
+    provided with an invalid (or non-existent) transform parameter.
+
+    These tests are started by the static_publisher.launch, which loads
+    parameters into the param server.
+
+    We check the output to make sure the correct error is occurring, since the
+    return code is always -1 (255).
+
+    Note that this *could* cause a problem if a valid TF is stored in the param
+    server for one of the names; in this case the subprocess would never return
+    and the test would run forever.
+    """
+
+    def test_publisher_no_args(self):
+        # Start the publisher with no argument.
+        cmd = 'rosrun tf2_ros static_transform_publisher'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            ret = subprocess.check_output(
+                cmd.split(' '), stderr=subprocess.STDOUT)
+        self.assertEqual(255, cm.exception.returncode)
+        self.assertIn('not having the right number of arguments',
+                      cm.exception.output)
+
+    def test_publisher_nonexistent_param(self):
+        # Here there is no paramater by that name.
+        cmd = 'rosrun tf2_ros static_transform_publisher /test_tf2/tf_null'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            ret = subprocess.check_output(
+                cmd.split(' '), stderr=subprocess.STDOUT)
+
+        self.assertEqual(255, cm.exception.returncode)
+        self.assertIn('Could not read TF', cm.exception.output)
+
+    def test_publisher_invalid_param(self):
+        # Here there is an invalid parameter stored in the parameter server.
+        cmd = 'rosrun tf2_ros static_transform_publisher /test_tf2/tf_invalid'
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            ret = subprocess.check_output(
+                cmd.split(' '), stderr=subprocess.STDOUT)
+
+        self.assertEqual(255, cm.exception.returncode)
+        self.assertIn('Could not validate XmlRpcC', cm.exception.output)
+
+
+if __name__ == '__main__':
+    rospy.init_node("test_static_publisher_py")
+    import rostest
+    rostest.rosrun(PKG, 'test_static_publisher_py', TestStaticPublisher)

--- a/test_tf2/test/test_tf_invalid.yaml
+++ b/test_tf2/test/test_tf_invalid.yaml
@@ -1,0 +1,7 @@
+# This is not a valid TF.
+
+child_frame_id: calibration
+some_data:
+    - 1
+    - 2
+    - 3

--- a/test_tf2/test/test_tf_valid.yaml
+++ b/test_tf2/test/test_tf_valid.yaml
@@ -1,0 +1,17 @@
+header:
+  seq: 0
+  stamp:
+    secs: 1619
+    nsecs: 601000000
+  frame_id: world
+child_frame_id: robot_calibration
+transform:
+  translation:
+    x: 0.75
+    y: 0.5
+    z: 1.0
+  rotation:
+    x: -0.62908825919
+    y: 0.210952809338
+    z: 0.640171445021
+    w: 0.38720459109

--- a/tf2_ros/package.xml
+++ b/tf2_ros/package.xml
@@ -2,7 +2,7 @@
   <name>tf2_ros</name>
   <version>0.5.13</version>
   <description>
-    This package contains the ROS bindings for the tf2 library, for both Python and C++. 
+    This package contains the ROS bindings for the tf2 library, for both Python and C++.
   </description>
   <author>Eitan Marder-Eppstein</author>
   <author>Wim Meeussen</author>
@@ -10,7 +10,7 @@
   <license>BSD</license>
 
   <url type="website">http://www.ros.org/wiki/tf2_ros</url>
-    
+
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <build_depend>actionlib</build_depend>
@@ -24,7 +24,8 @@
   <build_depend>tf2</build_depend>
   <build_depend>tf2_msgs</build_depend>
   <build_depend>tf2_py</build_depend>
- 
+  <build_depend>xmlrpcpp</build_depend>
+
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -36,13 +37,7 @@
   <run_depend>tf2</run_depend>
   <run_depend>tf2_msgs</run_depend>
   <run_depend>tf2_py</run_depend>
+  <run_depend>xmlrpcpp</run_depend>
 
   <test_depend>rostest</test_depend>
-
-
-
-
 </package>
-
-
-

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -36,17 +36,10 @@ int main(int argc, char ** argv)
   //Initialize ROS
   ros::init(argc, argv,"static_transform_publisher", ros::init_options::AnonymousName);
   tf2_ros::StaticTransformBroadcaster broadcaster;
+  geometry_msgs::TransformStamped msg;
 
   if(argc == 10)
   {
-
-    if (strcmp(argv[8], argv[9]) == 0)
-    {
-      ROS_FATAL("target_frame and source frame are the same (%s, %s) this cannot work", argv[8], argv[9]);
-      return 1;
-    }
-
-    geometry_msgs::TransformStamped msg;
     msg.transform.translation.x = atof(argv[1]);
     msg.transform.translation.y = atof(argv[2]);
     msg.transform.translation.z = atof(argv[3]);
@@ -57,24 +50,9 @@ int main(int argc, char ** argv)
     msg.header.stamp = ros::Time::now();
     msg.header.frame_id = argv[8];
     msg.child_frame_id = argv[9];
-  
-
-
-  broadcaster.sendTransform(msg);
-  ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
-  ros::spin();
-
-  return 0;
-} 
+  }
   else if (argc == 9)
   {
-    if (strcmp(argv[7], argv[8]) == 0)
-    {
-      ROS_FATAL("target_frame and source frame are the same (%s, %s) this cannot work", argv[7], argv[8]);
-      return 1;
-    }
-    
-    geometry_msgs::TransformStamped msg;
     msg.transform.translation.x = atof(argv[1]);
     msg.transform.translation.y = atof(argv[2]);
     msg.transform.translation.z = atof(argv[3]);
@@ -89,11 +67,6 @@ int main(int argc, char ** argv)
     msg.header.stamp = ros::Time::now();
     msg.header.frame_id = argv[7];
     msg.child_frame_id = argv[8];
-
-    broadcaster.sendTransform(msg);
-    ROS_INFO("Spinning until killed publishing %s to %s", msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
-    ros::spin();
-    return 0;
   }
   else
   {
@@ -108,6 +81,17 @@ int main(int argc, char ** argv)
     return -1;
   }
 
+  // Checks: frames should not be the same.
+  if (msg.header.frame_id == msg.child_frame_id)
+  {
+    ROS_FATAL("target_frame and source frame are the same (%s, %s) this cannot work",
+              msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
+    return 1;
+  }
 
+  broadcaster.sendTransform(msg);
+  ROS_INFO("Spinning until killed publishing %s to %s",
+           msg.header.frame_id.c_str(), msg.child_frame_id.c_str());
+  ros::spin();
+  return 0;
 };
-

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -31,6 +31,25 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include "tf2_ros/static_transform_broadcaster.h"
 
+
+bool validateXmlRpcTf(XmlRpc::XmlRpcValue tf_data) {
+  // Validate a TF stored in XML RPC format: ensures the appropriate fields
+  // exist. Note this does not check data types.
+  return tf_data.hasMember("child_frame_id") &&
+         tf_data.hasMember("header") &&
+         tf_data["header"].hasMember("frame_id") &&
+         tf_data.hasMember("transform") &&
+         tf_data["transform"].hasMember("translation") &&
+         tf_data["transform"]["translation"].hasMember("x") &&
+         tf_data["transform"]["translation"].hasMember("y") &&
+         tf_data["transform"]["translation"].hasMember("z") &&
+         tf_data["transform"].hasMember("rotation") &&
+         tf_data["transform"]["rotation"].hasMember("x") &&
+         tf_data["transform"]["rotation"].hasMember("y") &&
+         tf_data["transform"]["rotation"].hasMember("z") &&
+         tf_data["transform"]["rotation"].hasMember("w");
+};
+
 int main(int argc, char ** argv)
 {
   //Initialize ROS
@@ -68,6 +87,33 @@ int main(int argc, char ** argv)
     msg.header.frame_id = argv[7];
     msg.child_frame_id = argv[8];
   }
+  else if (argc == 2) {
+    const std::string param_name = argv[1];
+    ROS_INFO_STREAM("Looking for TF in parameter: " << param_name);
+    XmlRpc::XmlRpcValue tf_data;
+
+    if (!ros::param::has(param_name) || !ros::param::get(param_name, tf_data)) {
+      ROS_FATAL_STREAM("Could not read TF from parameter server: " << param_name);
+      return -1;
+    }
+
+    // Check that all required members are present & of the right type.
+    if (!validateXmlRpcTf(tf_data)) {
+      ROS_FATAL_STREAM("Could not validate XmlRpcC for TF data: " << tf_data);
+      return -1;
+    }
+
+    msg.transform.translation.x = (double) tf_data["transform"]["translation"]["x"];
+    msg.transform.translation.y = (double) tf_data["transform"]["translation"]["y"];
+    msg.transform.translation.z = (double) tf_data["transform"]["translation"]["z"];
+    msg.transform.rotation.x = (double) tf_data["transform"]["rotation"]["x"];
+    msg.transform.rotation.y = (double) tf_data["transform"]["rotation"]["y"];
+    msg.transform.rotation.z = (double) tf_data["transform"]["rotation"]["z"];
+    msg.transform.rotation.w = (double) tf_data["transform"]["rotation"]["w"];
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = (std::string) tf_data["header"]["frame_id"];
+    msg.child_frame_id = (std::string) tf_data["child_frame_id"];
+  }
   else
   {
     printf("A command line utility for manually sending a transform.\n");
@@ -75,6 +121,8 @@ int main(int argc, char ** argv)
     printf("Usage: static_transform_publisher x y z qx qy qz qw frame_id child_frame_id \n");
     printf("OR \n");
     printf("Usage: static_transform_publisher x y z yaw pitch roll frame_id child_frame_id \n");
+    printf("OR \n");
+    printf("Usage: static_transform_publisher /param_name \n");
     printf("\nThis transform is the transform of the coordinate frame from frame_id into the coordinate frame \n");
     printf("of the child_frame_id.  \n");
     ROS_ERROR("static_transform_publisher exited due to not having the right number of arguments");


### PR DESCRIPTION
This PR adds the ability to pass a ROS parameter name to the tf publisher, where the parameter contains the TF to publish:

```
static_transform_publisher /param_name
```

This can simplify some launching behavior: the TF can be stored in a YAML file and loaded directly into the param server. One example use case is storing a calibration TF as a file, and publishing it using the static_transform_publisher.

I also made some minor simplifications to the code, if those are annoying let me know and I'll update the PR.

I tested this using Travis, the log is [here](https://travis-ci.org/felixduvallet/geometry2/builds/134489229).
