### PR TITLE
Add tf2_eigen conversions for Pose and Point (not stamped)

### DIFF
--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(Eigen REQUIRED)
 include_directories(${EIGEN_INCLUDE_DIRS})
 add_definitions(${EIGEN_DEFINITIONS})
 
+include_directories(${catkin_INCLUDE_DIRS})
+
 include_directories(include)
 
 catkin_package(

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -73,7 +73,7 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
- * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * functions rely on the existence of a time stamp and a frame id in the type which should
  * get transformed.
  * \param t_in The vector to transform, as a Eigen Vector3d data type.
  * \param t_out The transformed vector, as a Eigen Vector3d data type.
@@ -159,7 +159,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
 /** \brief Apply a geometry_msgs Transform to a Eigen-specific affine transform data type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
- * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * functions rely on the existence of a time stamp and a frame id in the type which should
  * get transformed.
  * \param t_in The frame to transform, as a Eigen Affine3d transform.
  * \param t_out The transformed frame, as a Eigen Affine3d transform.
@@ -209,7 +209,7 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
 /** \brief Apply a geometry_msgs TransformStamped to a Eigen-specific affine transform data type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
- * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * functions rely on the existence of a time stamp and a frame id in the type which should
  * get transformed.
  * \param t_in The frame to transform, as a timestamped Eigen Affine3d transform.
  * \param t_out The transformed frame, as a timestamped Eigen Affine3d transform.
@@ -255,9 +255,9 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Affine3d
 
 
 namespace Eigen {
-// This is needed to make the usage of the following covnersion functions usable in tf2::convert().
+// This is needed to make the usage of the following conversion functions usable in tf2::convert().
 // According to clangs error note 'fromMsg'/'toMsg' should be declared prior to the call site or
-// in an associated namespace of one of its arguments. The stamped vorsions of this conversion
+// in an associated namespace of one of its arguments. The stamped versions of this conversion
 // functions work because they have tf2::Stamped as an argument which is the same namespace as
 // which 'fromMsg'/'toMsg' is defined in. The non-stamped versions have no argument which is
 // defined in tf2, so it take the following definitions in Eigen namespace to make them usable in

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -137,9 +137,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<Eigen::Vector3d>& in)
   geometry_msgs::PointStamped msg;
   msg.header.stamp = in.stamp_;
   msg.header.frame_id = in.frame_id_;
-  msg.point.x = in.x();
-  msg.point.y = in.y();
-  msg.point.z = in.z();
+  msg.point = toMsg(static_cast<const Eigen::Vector3d&>(in));
   return msg;
 }
 
@@ -152,60 +150,7 @@ inline
 void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3d>& out) {
   out.stamp_ = msg.header.stamp;
   out.frame_id_ = msg.header.frame_id;
-  out.x() = msg.point.x;
-  out.y() = msg.point.y;
-  out.z() = msg.point.z;
-}
-
-
-/** \brief Apply a geometry_msgs TransformStamped to a Eigen-specific affine transform data type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The frame to transform, as a timestamped Eigen Affine3d transform.
- * \param t_out The transformed frame, as a timestamped Eigen Affine3d transform.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template <>
-inline
-void doTransform(const tf2::Stamped<Eigen::Affine3d>& t_in,
-		 tf2::Stamped<Eigen::Affine3d>& t_out,
-		 const geometry_msgs::TransformStamped& transform) {
-  t_out = tf2::Stamped<Eigen::Affine3d>(transformToEigen(transform) * t_in, transform.header.stamp, transform.header.frame_id);
-}
-
-/** \brief Convert a stamped Eigen Affine3d transform type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped Eigen Affine3d to convert.
- * \return The Eigen transform converted to a PoseStamped message.
- */
-inline
-geometry_msgs::PoseStamped toMsg(const tf2::Stamped<Eigen::Affine3d>& in)
-{
-  geometry_msgs::PoseStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.pose.position.x = in.translation().x();
-  msg.pose.position.y = in.translation().y();
-  msg.pose.position.z = in.translation().z();
-  msg.pose.orientation.x = Eigen::Quaterniond(in.rotation()).x();
-  msg.pose.orientation.y = Eigen::Quaterniond(in.rotation()).y();
-  msg.pose.orientation.z = Eigen::Quaterniond(in.rotation()).z();
-  msg.pose.orientation.w = Eigen::Quaterniond(in.rotation()).w();
-  return msg;
-}
-
-/** \brief Convert a Pose message transform type to a stamped Eigen Affine3d.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg The PoseStamped message to convert.
- * \param out The pose converted to a timestamped Eigen Affine3d.
- */
-inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Affine3d>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out.setData(Eigen::Affine3d(Eigen::Translation3d(msg.pose.position.x, msg.pose.position.y, msg.pose.position.z)
-			       * Eigen::Quaterniond(msg.pose.orientation.w,
-						    msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z)));
+  fromMsg(msg.point, static_cast<Eigen::Vector3d&>(out));
 }
 
 /** \brief Apply a geometry_msgs Transform to a Eigen-specific affine transform data type.
@@ -253,6 +198,48 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
                          msg.orientation.x,
                          msg.orientation.y,
                          msg.orientation.z));
+}
+
+/** \brief Apply a geometry_msgs TransformStamped to a Eigen-specific affine transform data type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The frame to transform, as a timestamped Eigen Affine3d transform.
+ * \param t_out The transformed frame, as a timestamped Eigen Affine3d transform.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template <>
+inline
+void doTransform(const tf2::Stamped<Eigen::Affine3d>& t_in,
+		 tf2::Stamped<Eigen::Affine3d>& t_out,
+		 const geometry_msgs::TransformStamped& transform) {
+  t_out = tf2::Stamped<Eigen::Affine3d>(transformToEigen(transform) * t_in, transform.header.stamp, transform.header.frame_id);
+}
+
+/** \brief Convert a stamped Eigen Affine3d transform type to a Pose message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The timestamped Eigen Affine3d to convert.
+ * \return The Eigen transform converted to a PoseStamped message.
+ */
+inline
+geometry_msgs::PoseStamped toMsg(const tf2::Stamped<Eigen::Affine3d>& in)
+{
+  geometry_msgs::PoseStamped msg;
+  msg.header.stamp = in.stamp_;
+  msg.header.frame_id = in.frame_id_;
+  msg.pose = toMsg(static_cast<const Eigen::Affine3d&>(in));
+  return msg;
+}
+
+/** \brief Convert a Pose message transform type to a stamped Eigen Affine3d.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg The PoseStamped message to convert.
+ * \param out The pose converted to a timestamped Eigen Affine3d.
+ */
+inline
+void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Affine3d>& out)
+{
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  fromMsg(msg.pose, static_cast<Eigen::Affine3d&>(out));
 }
 
 } // namespace

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -87,6 +87,7 @@ void doTransform(const Eigen::Vector3d& t_in, Eigen::Vector3d& t_out, const geom
  * \param in The timestamped Eigen Vector3d to convert.
  * \return The vector converted to a Point message.
  */
+inline
 geometry_msgs::Point toMsg(const Eigen::Vector3d& in)
 {
   geometry_msgs::Point msg;
@@ -101,6 +102,7 @@ geometry_msgs::Point toMsg(const Eigen::Vector3d& in)
  * \param msg The Point message to convert.
  * \param out The point converted to a Eigen Vector3d.
  */
+inline
 void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out)
 {
   out.x() = msg.x;
@@ -225,6 +227,7 @@ void doTransform(const Eigen::Affine3d& t_in,
  * \param in The Eigen Affine3d to convert.
  * \return The Eigen transform converted to a Pose message.
  */
+inline
 geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
   geometry_msgs::Pose msg;
   msg.position.x = in.translation().x();
@@ -242,6 +245,7 @@ geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
  * \param msg The Pose message to convert.
  * \param out The pose converted to a Eigen Affine3d.
  */
+inline
 void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
   out = Eigen::Affine3d(
       Eigen::Translation3d(msg.position.x, msg.position.y, msg.position.z) *

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -71,7 +71,10 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * although it can not be used in tf2_ros::BufferInterface::transform because this
+ * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * get transformed.
  * \param t_in The vector to transform, as a Eigen Vector3d data type.
  * \param t_out The transformed vector, as a Eigen Vector3d data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -154,7 +157,10 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
 }
 
 /** \brief Apply a geometry_msgs Transform to a Eigen-specific affine transform data type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * although it can not be used in tf2_ros::BufferInterface::transform because this
+ * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * get transformed.
  * \param t_in The frame to transform, as a Eigen Affine3d transform.
  * \param t_out The transformed frame, as a Eigen Affine3d transform.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -201,7 +207,10 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to a Eigen-specific affine transform data type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * although it can not be used in tf2_ros::BufferInterface::transform because this
+ * functions rely on the existenz of a time stamp and a frame id in the type which should
+ * get transformed.
  * \param t_in The frame to transform, as a timestamped Eigen Affine3d transform.
  * \param t_out The transformed frame, as a timestamped Eigen Affine3d transform.
  * \param transform The timestamped transform to apply, as a TransformStamped message.

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -257,4 +257,36 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
 
 } // namespace
 
+
+namespace Eigen {
+// This is needed to make the usage of the following covnersion functions usable in tf2::convert().
+// According to clangs error note 'fromMsg'/'toMsg' should be declared prior to the call site or
+// in an associated namespace of one of its arguments. The stamped vorsions of this conversion
+// functions work because they have tf2::Stamped as an argument which is the same namespace as
+// which 'fromMsg'/'toMsg' is defined in. The non-stamped versions have no argument which is
+// defined in tf2, so it take the following definitions in Eigen namespace to make them usable in
+// tf2::convert().
+
+inline
+geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
+  return tf2::toMsg(in);
+}
+
+inline
+void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out) {
+  tf2::fromMsg(msg, out);
+}
+
+inline
+geometry_msgs::Point toMsg(const Eigen::Vector3d& in) {
+  return tf2::toMsg(in);
+}
+
+inline
+void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
+  tf2::fromMsg(msg, out);
+}
+
+} // namespace
+
 #endif // TF2_EIGEN_H

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -70,6 +70,43 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
   return t;
 }
 
+/** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The vector to transform, as a Eigen Vector3d data type.
+ * \param t_out The transformed vector, as a Eigen Vector3d data type.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template <>
+void doTransform(const Eigen::Vector3d& t_in, Eigen::Vector3d& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  t_out = Eigen::Vector3d(transformToEigen(transform) * t_in);
+}
+
+/** \brief Convert a Eigen Vector3d type to a Point message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The timestamped Eigen Vector3d to convert.
+ * \return The vector converted to a Point message.
+ */
+geometry_msgs::Point toMsg(const Eigen::Vector3d& in)
+{
+  geometry_msgs::Point msg;
+  msg.x = in.x();
+  msg.y = in.y();
+  msg.z = in.z();
+  return msg;
+}
+
+/** \brief Convert a Point message type to a Eigen-specific Vector3d type.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * \param msg The Point message to convert.
+ * \param out The point converted to a Eigen Vector3d.
+ */
+void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out)
+{
+  out.x() = msg.x;
+  out.y() = msg.y;
+  out.z() = msg.z;
+}
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -206,6 +206,51 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Affine3d
 						    msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z)));
 }
 
+/** \brief Apply a geometry_msgs Transform to a Eigen-specific affine transform data type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The frame to transform, as a Eigen Affine3d transform.
+ * \param t_out The transformed frame, as a Eigen Affine3d transform.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template <>
+void doTransform(const Eigen::Affine3d& t_in,
+                 Eigen::Affine3d& t_out,
+                 const geometry_msgs::TransformStamped& transform) {
+  t_out = Eigen::Affine3d(transformToEigen(transform) * t_in);
+}
+
+
+/** \brief Convert a Eigen Affine3d transform type to a Pose message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The Eigen Affine3d to convert.
+ * \return The Eigen transform converted to a Pose message.
+ */
+geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
+  geometry_msgs::Pose msg;
+  msg.position.x = in.translation().x();
+  msg.position.y = in.translation().y();
+  msg.position.z = in.translation().z();
+  msg.orientation.x = Eigen::Quaterniond(in.rotation()).x();
+  msg.orientation.y = Eigen::Quaterniond(in.rotation()).y();
+  msg.orientation.z = Eigen::Quaterniond(in.rotation()).z();
+  msg.orientation.w = Eigen::Quaterniond(in.rotation()).w();
+  return msg;
+}
+
+/** \brief Convert a Pose message transform type to a Eigen Affine3d.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg The Pose message to convert.
+ * \param out The pose converted to a Eigen Affine3d.
+ */
+void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
+  out = Eigen::Affine3d(
+      Eigen::Translation3d(msg.position.x, msg.position.y, msg.position.z) *
+      Eigen::Quaterniond(msg.orientation.w,
+                         msg.orientation.x,
+                         msg.orientation.y,
+                         msg.orientation.z));
+}
+
 } // namespace
 
 #endif // TF2_EIGEN_H

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -34,25 +34,60 @@
 
 static const double EPS = 1e-3;
 
-
-TEST(TfEigen, ConvertVector)
+TEST(TfEigen, ConvertVector3dStamped)
 {
-  Eigen::Vector3d v(1,2,3);
+  const tf2::Stamped<Eigen::Vector3d> v(Eigen::Vector3d(1,2,3), ros::Time(5), "test");
 
-  Eigen::Vector3d v1 = v;
-  tf2::convert(v1, v1);
+  tf2::Stamped<Eigen::Vector3d> v1;
+  geometry_msgs::PointStamped p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
 
   EXPECT_EQ(v, v1);
-
-  Eigen::Vector3d v2(3,4,5);
-  tf2::convert(v1, v2);
-
-  EXPECT_EQ(v, v2);
-  EXPECT_EQ(v1, v2);  
-  
 }
 
-TEST(TfEigen, ConvertPose)
+TEST(TfEigen, ConvertVector3d)
+{
+  const Eigen::Vector3d v(1,2,3);
+
+  Eigen::Vector3d v1;
+  geometry_msgs::Point p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
+
+  EXPECT_EQ(v, v1);
+}
+
+TEST(TfEigen, ConvertAffine3dStamped)
+{
+  const Eigen::Affine3d v_nonstamped(Eigen::Translation3d(1,2,3) * Eigen::AngleAxis<double>(1, Eigen::Vector3d::UnitX()));
+  const tf2::Stamped<Eigen::Affine3d> v(v_nonstamped, ros::Time(42), "test_frame");
+
+  tf2::Stamped<Eigen::Affine3d> v1;
+  geometry_msgs::PoseStamped p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
+
+  EXPECT_EQ(v.translation(), v1.translation());
+  EXPECT_EQ(v.rotation(), v1.rotation());
+  EXPECT_EQ(v.frame_id_, v1.frame_id_);
+  EXPECT_EQ(v.stamp_, v1.stamp_);
+}
+
+TEST(TfEigen, ConvertAffine3d)
+{
+  const Eigen::Affine3d v(Eigen::Translation3d(1,2,3) * Eigen::AngleAxis<double>(1, Eigen::Vector3d::UnitX()));
+
+  Eigen::Affine3d v1;
+  geometry_msgs::Pose p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
+
+  EXPECT_EQ(v.translation(), v1.translation());
+  EXPECT_EQ(v.rotation(), v1.rotation());
+}
+
+TEST(TfEigen, ConvertTransform)
 {
   Eigen::Matrix4d tm;
   


### PR DESCRIPTION
Added conversions (fromMsg/toMsg) for:
- geometry_msgs::Pose <-> Eigen::Affine3d and
- geometry_msgs::Point<-> Eigen::Vector3d
  (analogous to their stamped counterparts). 

The achieve compatibility with tf2::convert(), a redefinition of the conversion functions in Eigen namespace had to be added. This had to be done, because the declaration of fromMsg/toMsg has to be done prior to the call site or in an associated namespace of one of its arguments.

Finally some tests have been added.
