### PR TITLE
Drop roslib.load_manifest

### DIFF
--- a/tf2_ros/doc/conf.py
+++ b/tf2_ros/doc/conf.py
@@ -11,8 +11,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import roslib
-roslib.load_manifest('tf')
 import sys, os
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
Unneeded with catkin, and it screws up doc-generation workflows that depend PYTHONPATH only (as opposed to ROS_PACKAGE_PATH).