### PR TITLE
fixes #194 check for quaternion normalization before inserting into storage

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -241,6 +241,19 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
     error_exists = true;
   }
 
+  bool valid = std::abs((stripped.transform.rotation.w * stripped.transform.rotation.w
+                        + stripped.transform.rotation.x * stripped.transform.rotation.x
+                        + stripped.transform.rotation.y * stripped.transform.rotation.y
+                        + stripped.transform.rotation.z * stripped.transform.rotation.z) - 1.0f) < 10e-6;
+
+  if (!valid) 
+  {
+    logError("TF_DENORMALIZED_QUATERNION: Ignoring transform for child_frame_id \"%s\" from authority \"%s\" because of an invalid quaternion in the transform (%f %f %f %f)",
+             stripped.child_frame_id.c_str(), authority.c_str(),
+             stripped.transform.rotation.x, stripped.transform.rotation.y, stripped.transform.rotation.z, stripped.transform.rotation.w);
+    error_exists = true;
+  }
+
   if (error_exists)
     return false;
   

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -75,6 +75,18 @@ TEST(tf2, setTransformValid)
   
 }
 
+TEST(tf2, setTransformInvalidQuaternion)
+{
+  tf2::BufferCore tfc;
+  geometry_msgs::TransformStamped st;
+  st.header.frame_id = "foo";
+  st.header.stamp = ros::Time(1.0);
+  st.child_frame_id = "child";
+  st.transform.rotation.w = 0;
+  EXPECT_FALSE(tfc.setTransform(st, "authority1"));
+  
+}
+
 TEST(tf2_lookupTransform, LookupException_Nothing_Exists)
 {
   tf2::BufferCore tfc;


### PR DESCRIPTION
@tfoote Is this what you had in mind here at #194? 

This checks for normalization, but maybe a better idea is to check for `q.dot(q) != 0` for an invalid quaternion instead?