### PR TITLE
fixup #186: inline template specializations

### DIFF
--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -80,6 +80,7 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
  * \param transform The timestamped transform to apply, as a TransformStamped message.
  */
 template <>
+inline
 void doTransform(const Eigen::Vector3d& t_in, Eigen::Vector3d& t_out, const geometry_msgs::TransformStamped& transform)
 {
   t_out = Eigen::Vector3d(transformToEigen(transform) * t_in);
@@ -166,6 +167,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
  * \param transform The timestamped transform to apply, as a TransformStamped message.
  */
 template <>
+inline
 void doTransform(const Eigen::Affine3d& t_in,
                  Eigen::Affine3d& t_out,
                  const geometry_msgs::TransformStamped& transform) {


### PR DESCRIPTION
#186 introduced a bug: full template specializations need to be inlined or implemented in a .cpp file. 
Otherwise one gets multiple definition linker errors:

```
CMakeFiles/hlrc_server.dir/src/MiddlewareROS.cpp.o: In function `void tf2::doTransform<Eigen::Matrix<double, 3, 1, 0, 3, 1> >(Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, Eigen::Matrix<double, 3, 1, 0, 3, 1>&, geometry_msgs::TransformStamped_<std::allocator<void> > const&)':
/opt/ros/kinetic/include/tf2_eigen/tf2_eigen.h:84: multiple definition of `void tf2::doTransform<Eigen::Matrix<double, 3, 1, 0, 3, 1> >(Eigen::Matrix<double, 3, 1, 0, 3, 1> const&, Eigen::Matrix<double, 3, 1, 0, 3, 1>&, geometry_msgs::TransformStamped_<std::allocator<void> > const&)'
CMakeFiles/hlrc_server.dir/src/main.cpp.o:/opt/ros/kinetic/include/tf2_eigen/tf2_eigen.h:84: first defined here
```