### PR TITLE
tf2_geometry_msgs: added missing conversion functions

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -52,11 +52,42 @@ namespace tf2
  */
 inline
 KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
-  {
-    return KDL::Frame(KDL::Rotation::Quaternion(t.transform.rotation.x, t.transform.rotation.y, 
-						t.transform.rotation.z, t.transform.rotation.w),
-		      KDL::Vector(t.transform.translation.x, t.transform.translation.y, t.transform.translation.z));
-  }
+{
+  return KDL::Frame(KDL::Rotation::Quaternion(t.transform.rotation.x, t.transform.rotation.y, 
+                      t.transform.rotation.z, t.transform.rotation.w),
+            KDL::Vector(t.transform.translation.x, t.transform.translation.y, t.transform.translation.z));
+}
+
+
+/*************/
+/** Vector3 **/
+/*************/
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::Vector3 toMsg(const tf2::Vector3& in)
+{
+  geometry_msgs::Vector3 out;
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::Vector3& in, tf2::Vector3& out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
 
 
 /********************/
@@ -89,15 +120,15 @@ inline
  */
 template <>
 inline
-  void doTransform(const geometry_msgs::Vector3Stamped& t_in, geometry_msgs::Vector3Stamped& t_out, const geometry_msgs::TransformStamped& transform)
-  {
-    KDL::Vector v_out = gmTransformToKDL(transform).M * KDL::Vector(t_in.vector.x, t_in.vector.y, t_in.vector.z);
-    t_out.vector.x = v_out[0];
-    t_out.vector.y = v_out[1];
-    t_out.vector.z = v_out[2];
-    t_out.header.stamp = transform.header.stamp;
-    t_out.header.frame_id = transform.header.frame_id;
-  }
+void doTransform(const geometry_msgs::Vector3Stamped& t_in, geometry_msgs::Vector3Stamped& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  KDL::Vector v_out = gmTransformToKDL(transform).M * KDL::Vector(t_in.vector.x, t_in.vector.y, t_in.vector.z);
+  t_out.vector.x = v_out[0];
+  t_out.vector.y = v_out[1];
+  t_out.vector.z = v_out[2];
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
 
 /** \brief Trivial "conversion" function for Vector3 message type.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
@@ -111,7 +142,7 @@ geometry_msgs::Vector3Stamped toMsg(const geometry_msgs::Vector3Stamped& in)
 }
 
 /** \brief Trivial "conversion" function for Vector3 message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param msg A Vector3Stamped message.
  * \param out The input argument.
  */
@@ -121,6 +152,65 @@ void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Sta
   out = msg;
 }
 
+/** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
+ * \return The Vector3Stamped converted to a geometry_msgs Vector3Stamped message type.
+ */
+template <>
+inline
+geometry_msgs::Vector3Stamped toMsg(const tf2::Stamped<tf2::Vector3>& in)
+{
+  geometry_msgs::Vector3Stamped out;
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  out.vector.x = in.getX();
+  out.vector.y = in.getY();
+  out.vector.z = in.getZ();
+  return out;
+}
+
+/** \brief Convert a Vector3Stamped message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param msg A Vector3Stamped message.
+ * \param out The Vector3Stamped converted to the equivalent tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::Vector3Stamped& msg, tf2::Stamped<tf2::Vector3>& out)
+{
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  out.setData(tf2::Vector3(msg.vector.x, msg.vector.y, msg.vector.z));
+}
+
+
+/***********/
+/** Point **/
+/***********/
+
+/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Vector3 object.
+ * \return The Vector3 converted to a geometry_msgs message type.
+ */
+inline
+void toMsg(const tf2::Vector3& in, geometry_msgs::Point& out)
+{
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+}
+
+/** \brief Convert a Vector3 message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A Vector3 message type.
+ * \param out The Vector3 converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::Point& in, tf2::Vector3& out)
+{
+  out = tf2::Vector3(in.x, in.y, in.z);
+}
 
 
 /******************/
@@ -153,15 +243,15 @@ inline
  */
 template <>
 inline
-  void doTransform(const geometry_msgs::PointStamped& t_in, geometry_msgs::PointStamped& t_out, const geometry_msgs::TransformStamped& transform)
-  {
-    KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.point.x, t_in.point.y, t_in.point.z);
-    t_out.point.x = v_out[0];
-    t_out.point.y = v_out[1];
-    t_out.point.z = v_out[2];
-    t_out.header.stamp = transform.header.stamp;
-    t_out.header.frame_id = transform.header.frame_id;
-  }
+void doTransform(const geometry_msgs::PointStamped& t_in, geometry_msgs::PointStamped& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.point.x, t_in.point.y, t_in.point.z);
+  t_out.point.x = v_out[0];
+  t_out.point.y = v_out[1];
+  t_out.point.z = v_out[2];
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
 
 /** \brief Trivial "conversion" function for Point message type.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
@@ -175,7 +265,7 @@ geometry_msgs::PointStamped toMsg(const geometry_msgs::PointStamped& in)
 }
 
 /** \brief Trivial "conversion" function for Point message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param msg A PointStamped message.
  * \param out The input argument.
  */
@@ -185,71 +275,35 @@ void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped
   out = msg;
 }
 
-
-/*****************/
-/** PoseStamped **/
-/*****************/
-
-/** \brief Extract a timestamp from the header of a Pose message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t PoseStamped message to extract the timestamp from.
- * \return The timestamp of the message.
- */
-template <>
-inline
-  const ros::Time& getTimestamp(const geometry_msgs::PoseStamped& t)  {return t.header.stamp;}
-
-/** \brief Extract a frame ID from the header of a Pose message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t PoseStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
- */
-template <>
-inline
-  const std::string& getFrameId(const geometry_msgs::PoseStamped& t)  {return t.header.frame_id;}
-
-/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The pose to transform, as a timestamped Pose3 message.
- * \param t_out The transformed pose, as a timestamped Pose3 message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template <>
-inline
-  void doTransform(const geometry_msgs::PoseStamped& t_in, geometry_msgs::PoseStamped& t_out, const geometry_msgs::TransformStamped& transform)
-  {
-    KDL::Vector v(t_in.pose.position.x, t_in.pose.position.y, t_in.pose.position.z);
-    KDL::Rotation r = KDL::Rotation::Quaternion(t_in.pose.orientation.x, t_in.pose.orientation.y, t_in.pose.orientation.z, t_in.pose.orientation.w);
-
-    KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
-    t_out.pose.position.x = v_out.p[0];
-    t_out.pose.position.y = v_out.p[1];
-    t_out.pose.position.z = v_out.p[2];
-    v_out.M.GetQuaternion(t_out.pose.orientation.x, t_out.pose.orientation.y, t_out.pose.orientation.z, t_out.pose.orientation.w);
-    t_out.header.stamp = transform.header.stamp;
-    t_out.header.frame_id = transform.header.frame_id;
-  }
-
-/** \brief Trivial "conversion" function for Pose message type.
+/** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A PoseStamped message.
- * \return The input argument.
+ * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
+ * \return The Vector3Stamped converted to a geometry_msgs PointStamped message type.
  */
+template <>
 inline
-geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
+geometry_msgs::PointStamped toMsg(const tf2::Stamped<tf2::Vector3>& in)
 {
-  return in;
+  geometry_msgs::PointStamped out;
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  out.point.x = in.getX();
+  out.point.y = in.getY();
+  out.point.z = in.getZ();
+  return out;
 }
 
-/** \brief Trivial "conversion" function for Pose message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A PoseStamped message.
- * \param out The input argument.
+/** \brief Convert a PointStamped message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param msg A PointStamped message.
+ * \param out The PointStamped converted to the equivalent tf2 type.
  */
 inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& out)
+void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<tf2::Vector3>& out)
 {
-  out = msg;
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  out.setData(tf2::Vector3(msg.point.x, msg.point.y, msg.point.z));
 }
 
 
@@ -274,7 +328,7 @@ geometry_msgs::Quaternion toMsg(const tf2::Quaternion& in)
 }
 
 /** \brief Convert a Quaternion message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param in A Quaternion message type.
  * \param out The Quaternion converted to a tf2 type.
  */
@@ -338,7 +392,7 @@ geometry_msgs::QuaternionStamped toMsg(const geometry_msgs::QuaternionStamped& i
 }
 
 /** \brief Trivial "conversion" function for Quaternion message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param msg A QuaternionStamped message.
  * \param out The input argument.
  */
@@ -350,7 +404,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& msg, geometry_msgs::Quatern
 
 /** \brief Convert as stamped tf2 Quaternion type to its equivalent geometry_msgs representation.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A instance of the tf2::Quaternion specialization of the tf2::Stamped template.
+ * \param in An instance of the tf2::Quaternion specialization of the tf2::Stamped template.
  * \return The QuaternionStamped converted to a geometry_msgs QuaternionStamped message type.
  */
 template <>
@@ -368,7 +422,7 @@ geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
 }
 
 /** \brief Convert a QuaternionStamped message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param in A QuaternionStamped message type.
  * \param out The QuaternionStamped converted to the equivalent tf2 type.
  */
@@ -381,6 +435,165 @@ void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quate
   tf2::Quaternion tmp;
   fromMsg(in.quaternion, tmp);
   out.setData(tmp);
+}
+
+
+/**********/
+/** Pose **/
+/**********/
+
+/** \brief Convert a tf2 Transform type to an equivalent geometry_msgs Pose message.
+ * \param in A tf2 Transform object.
+ * \param out The Transform converted to a geometry_msgs Pose message type.
+ */
+inline
+void toMsg(const tf2::Transform& in, geometry_msgs::Pose& out)
+{
+  toMsg(in.getOrigin(), out.position);
+  out.orientation = toMsg(in.getRotation());
+}
+
+/** \brief Convert a geometry_msgs Pose message to an equivalent tf2 Transform type.
+ * \param in A Pose message.
+ * \param out The Pose converted to a tf2 Transform type.
+ */
+inline
+void fromMsg(const geometry_msgs::Pose& in, tf2::Transform& out)
+{
+  out.setOrigin(tf2::Vector3(in.position.x, in.position.y, in.position.z));
+  // w at the end in the constructor
+  out.setRotation(tf2::Quaternion(in.orientation.x, in.orientation.y, in.orientation.z, in.orientation.w));
+}
+
+
+/*****************/
+/** PoseStamped **/
+/*****************/
+
+/** \brief Extract a timestamp from the header of a Pose message.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * \param t PoseStamped message to extract the timestamp from.
+ * \return The timestamp of the message.
+ */
+template <>
+inline
+  const ros::Time& getTimestamp(const geometry_msgs::PoseStamped& t)  {return t.header.stamp;}
+
+/** \brief Extract a frame ID from the header of a Pose message.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * \param t PoseStamped message to extract the frame ID from.
+ * \return A string containing the frame ID of the message.
+ */
+template <>
+inline
+  const std::string& getFrameId(const geometry_msgs::PoseStamped& t)  {return t.header.frame_id;}
+
+/** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
+ * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * \param t_in The pose to transform, as a timestamped Pose3 message.
+ * \param t_out The transformed pose, as a timestamped Pose3 message.
+ * \param transform The timestamped transform to apply, as a TransformStamped message.
+ */
+template <>
+inline
+void doTransform(const geometry_msgs::PoseStamped& t_in, geometry_msgs::PoseStamped& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  KDL::Vector v(t_in.pose.position.x, t_in.pose.position.y, t_in.pose.position.z);
+  KDL::Rotation r = KDL::Rotation::Quaternion(t_in.pose.orientation.x, t_in.pose.orientation.y, t_in.pose.orientation.z, t_in.pose.orientation.w);
+
+  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
+  t_out.pose.position.x = v_out.p[0];
+  t_out.pose.position.y = v_out.p[1];
+  t_out.pose.position.z = v_out.p[2];
+  v_out.M.GetQuaternion(t_out.pose.orientation.x, t_out.pose.orientation.y, t_out.pose.orientation.z, t_out.pose.orientation.w);
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A PoseStamped message.
+ * \return The input argument.
+ */
+inline
+geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
+{
+  return in;
+}
+
+/** \brief Trivial "conversion" function for Pose message type.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A PoseStamped message.
+ * \param out The input argument.
+ */
+inline
+void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& out)
+{
+  out = msg;
+}
+
+/** \brief Convert as stamped tf2 Pose type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in An instance of the tf2::Pose specialization of the tf2::Stamped template.
+ * \return The PoseStamped converted to a geometry_msgs PoseStamped message type.
+ */
+template <>
+inline
+geometry_msgs::PoseStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
+{
+  geometry_msgs::PoseStamped out;
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  toMsg(in.getOrigin(), out.pose.position);
+  out.pose.orientation = toMsg(in.getRotation());
+  return out;
+}
+
+/** \brief Convert a PoseStamped message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param msg A PoseStamped message.
+ * \param out The PoseStamped converted to the equivalent tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<tf2::Transform>& out)
+{
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  tf2::Transform tmp;
+  fromMsg(msg.pose, tmp);
+  out.setData(tmp);
+}
+
+
+/***************/
+/** Transform **/
+/***************/
+
+/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A tf2 Transform object.
+ * \return The Transform converted to a geometry_msgs message type.
+ */
+inline
+geometry_msgs::Transform toMsg(const tf2::Transform& in)
+{
+  geometry_msgs::Transform out;
+  out.translation = toMsg(in.getOrigin());
+  out.rotation = toMsg(in.getRotation());
+  return out;
+}
+
+/** \brief Convert a Transform message to its equivalent tf2 representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in A Transform message type.
+ * \param out The Transform converted to a tf2 type.
+ */
+inline
+void fromMsg(const geometry_msgs::Transform& in, tf2::Transform& out)
+{
+  out.setOrigin(tf2::Vector3(in.translation.x, in.translation.y, in.translation.z));
+  // w at the end in the constructor
+  out.setRotation(tf2::Quaternion(in.rotation.x, in.rotation.y, in.rotation.z, in.rotation.w));
 }
 
 
@@ -415,21 +628,21 @@ const std::string& getFrameId(const geometry_msgs::TransformStamped& t)  {return
 template <>
 inline
 void doTransform(const geometry_msgs::TransformStamped& t_in, geometry_msgs::TransformStamped& t_out, const geometry_msgs::TransformStamped& transform)
-  {
-    KDL::Vector v(t_in.transform.translation.x, t_in.transform.translation.y,
-                  t_in.transform.translation.z);
-    KDL::Rotation r = KDL::Rotation::Quaternion(t_in.transform.rotation.x,
-                                                t_in.transform.rotation.y, t_in.transform.rotation.z, t_in.transform.rotation.w);
+{
+  KDL::Vector v(t_in.transform.translation.x, t_in.transform.translation.y,
+                t_in.transform.translation.z);
+  KDL::Rotation r = KDL::Rotation::Quaternion(t_in.transform.rotation.x,
+                                              t_in.transform.rotation.y, t_in.transform.rotation.z, t_in.transform.rotation.w);
 
-    KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
-    t_out.transform.translation.x = v_out.p[0];
-    t_out.transform.translation.y = v_out.p[1];
-    t_out.transform.translation.z = v_out.p[2];
-    v_out.M.GetQuaternion(t_out.transform.rotation.x, t_out.transform.rotation.y,
-                          t_out.transform.rotation.z, t_out.transform.rotation.w);
-    t_out.header.stamp = transform.header.stamp;
-    t_out.header.frame_id = transform.header.frame_id;
-  }
+  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
+  t_out.transform.translation.x = v_out.p[0];
+  t_out.transform.translation.y = v_out.p[1];
+  t_out.transform.translation.z = v_out.p[2];
+  v_out.M.GetQuaternion(t_out.transform.rotation.x, t_out.transform.rotation.y,
+                        t_out.transform.rotation.z, t_out.transform.rotation.w);
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
 
 /** \brief Trivial "conversion" function for Transform message type.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
@@ -453,68 +666,37 @@ void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::Transfor
   out = msg;
 }
 
-
-/***************/
-/** Transform **/
-/***************/
-
-/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
+/** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Transform object.
- * \return The Transform converted to a geometry_msgs message type.
+ * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.
+ * \return The TransformStamped converted to a geometry_msgs TransformStamped message type.
  */
+template <>
 inline
-geometry_msgs::Transform toMsg(const tf2::Transform& in)
+geometry_msgs::TransformStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
 {
-  geometry_msgs::Transform out;
-  out.translation.x = in.getOrigin().getX();
-  out.translation.y = in.getOrigin().getY();
-  out.translation.z = in.getOrigin().getZ();
-  out.rotation = toMsg(in.getRotation());
+  geometry_msgs::TransformStamped out;
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  out.transform.translation = toMsg(in.getOrigin());
+  out.transform.rotation = toMsg(in.getRotation());
   return out;
 }
 
-/** \brief Convert a Transform message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A Transform message type.
- * \param out The Transform converted to a tf2 type.
+/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param in A TransformStamped message type.
+ * \param out The TransformStamped converted to a tf2 type.
  */
+template <>
 inline
-void fromMsg(const geometry_msgs::Transform& in, tf2::Transform& out)
+void fromMsg(const geometry_msgs::TransformStamped& in, tf2::Stamped<tf2::Transform>& out)
 {
-  out.setOrigin(tf2::Vector3(in.translation.x, in.translation.y, in.translation.z));
-  // w at the end in the constructor
-  out.setRotation(tf2::Quaternion(in.rotation.x, in.rotation.y, in.rotation.z, in.rotation.w));
-}
-
-
-/**********/
-/** Pose **/
-/**********/
-
-/** \brief Convert a tf2 Transform type to an equivalent geometry_msgs Pose message.
- * \param in A tf2 Transform object.
- * \param out The Transform converted to a geometry_msgs Pose message type.
- */
-inline
-void toMsg(const tf2::Transform& in, geometry_msgs::Pose& out )
-{
-  out.position.x = in.getOrigin().getX();
-  out.position.y = in.getOrigin().getY();
-  out.position.z = in.getOrigin().getZ();
-  out.orientation = toMsg(in.getRotation());
-}
-
-/** \brief Convert a geometry_msgs Pose message to an equivalent tf2 Transform type.
- * \param in A Pose message.
- * \param out The Pose converted to a tf2 Transform type.
- */
-inline
-void fromMsg(const geometry_msgs::Pose& in, tf2::Transform& out)
-{
-  out.setOrigin(tf2::Vector3(in.position.x, in.position.y, in.position.z));
-  // w at the end in the constructor
-  out.setRotation(tf2::Quaternion(in.orientation.x, in.orientation.y, in.orientation.z, in.orientation.w));
+  out.stamp_ = in.header.stamp;
+  out.frame_id_ = in.header.frame_id;
+  tf2::Transform tmp;
+  fromMsg(in.transform, tmp);
+  out.setData(tmp);
 }
 
 } // namespace


### PR DESCRIPTION
Fixed a few indentation and documentation errors, and added the missing fromMsg and toMsg functions.