### PR TITLE
BufferServers uses node name as action namespace

### DIFF
--- a/tf2_ros/src/buffer_server_main.cpp
+++ b/tf2_ros/src/buffer_server_main.cpp
@@ -63,7 +63,7 @@ int main(int argc, char** argv)
   // WIM: this works fine:
   tf2_ros::Buffer buffer_core(ros::Duration(buffer_size+0)); // WTF??
   tf2_ros::TransformListener listener(buffer_core);
-  tf2_ros::BufferServer buffer_server(buffer_core, "tf2_buffer_server", false);
+  tf2_ros::BufferServer buffer_server(buffer_core, ros::this_node::getName(), false);
   buffer_server.start();
   // But you should probably read this instead:
   // http://www.informit.com/guides/content.aspx?g=cplusplus&seqNum=439


### PR DESCRIPTION
instead of fixed namespace `tf2_buffer_server`.

 It confused me when I tried to use two tf2 buffer server with different names.