### PR TITLE
Switch tf2_eigen to use package.xml format 2.

### DIFF
--- a/tf2_eigen/package.xml
+++ b/tf2_eigen/package.xml
@@ -9,12 +9,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
+
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>geometry_msgs</build_depend>
-  <build_depend>tf2</build_depend>
 
-  <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>tf2</exec_depend>
+  <build_export_depend>eigen</build_export_depend>
 
 </package>

--- a/tf2_eigen/package.xml
+++ b/tf2_eigen/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>tf2_eigen</name>
   <version>0.5.15</version>
   <description>tf2_eigen</description>
@@ -8,13 +8,13 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf2</build_depend>
-  <build_depend>cmake_modules</build_depend>
 
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>cmake_modules</run_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf2</exec_depend>
 
 </package>


### PR DESCRIPTION
This is to modernize it a bit to make it more compatible
with ROS 2.  While we are in here, remove the run/exec dependency
on cmake_modules, which doesn't seem to be needed at runtime.

Signed-off-by: Chris Lalancette <clalancette@osrfoundation.org>