### PR TITLE
Document lifetime of returned reference for getTimestamp and getFrameId

### DIFF
--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -54,7 +54,8 @@ template <class T>
 
 /**\brief Get the timestamp from data 
  * \param t The data input.
- * \return The timestamp associated with the data. 
+ * \return The timestamp associated with the data. The lifetime of the returned
+ * reference is bound to the life time of the argument.
  */
 template <class T>
   const ros::Time& getTimestamp(const T& t);

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -55,7 +55,7 @@ template <class T>
 /**\brief Get the timestamp from data 
  * \param t The data input.
  * \return The timestamp associated with the data. The lifetime of the returned
- * reference is bound to the life time of the argument.
+ * reference is bound to the lifetime of the argument.
  */
 template <class T>
   const ros::Time& getTimestamp(const T& t);
@@ -63,7 +63,7 @@ template <class T>
 /**\brief Get the frame_id from data 
  * \param t The data input.
  * \return The frame_id associated with the data. The lifetime of the returned
- * reference is bound to the life time of the argument.
+ * reference is bound to the lifetime of the argument.
  */
 template <class T>
   const std::string& getFrameId(const T& t);

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -62,7 +62,8 @@ template <class T>
 
 /**\brief Get the frame_id from data 
  * \param t The data input.
- * \return The frame_id associated with the data. 
+ * \return The frame_id associated with the data. The lifetime of the returned
+ * reference is bound to the life time of the argument.
  */
 template <class T>
   const std::string& getFrameId(const T& t);

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -67,7 +67,7 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t VectorStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -77,7 +77,7 @@ inline
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t VectorStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -133,7 +133,7 @@ void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Sta
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t PointStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -143,7 +143,7 @@ inline
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t PointStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -198,7 +198,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t PoseStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -208,7 +208,7 @@ inline
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t PoseStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -300,7 +300,7 @@ void fromMsg(const geometry_msgs::Quaternion& in, tf2::Quaternion& out)
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t QuaternionStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -310,7 +310,7 @@ const ros::Time& getTimestamp(const geometry_msgs::QuaternionStamped& t)  {retur
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t QuaternionStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -400,7 +400,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quate
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t TransformStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -410,7 +410,7 @@ const ros::Time& getTimestamp(const geometry_msgs::TransformStamped& t)  {return
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t TransformStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -66,7 +66,8 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
 /** \brief Extract a timestamp from the header of a Vector message.
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t VectorStamped message to extract the timestamp from.
- * \return The timestamp of the message.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
  */
 template <>
 inline
@@ -130,7 +131,8 @@ void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Sta
 /** \brief Extract a timestamp from the header of a Point message.
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t PointStamped message to extract the timestamp from.
- * \return The timestamp of the message.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
  */
 template <>
 inline
@@ -193,7 +195,8 @@ void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped
 /** \brief Extract a timestamp from the header of a Pose message.
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t PoseStamped message to extract the timestamp from.
- * \return The timestamp of the message.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
  */
 template <>
 inline
@@ -293,7 +296,8 @@ void fromMsg(const geometry_msgs::Quaternion& in, tf2::Quaternion& out)
 /** \brief Extract a timestamp from the header of a Quaternion message.
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t QuaternionStamped message to extract the timestamp from.
- * \return The timestamp of the message.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
  */
 template <>
 inline
@@ -391,7 +395,8 @@ void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quate
 /** \brief Extract a timestamp from the header of a Transform message.
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t TransformStamped message to extract the timestamp from.
- * \return The timestamp of the message.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
  */
 template <>
 inline

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -76,7 +76,8 @@ inline
 /** \brief Extract a frame ID from the header of a Vector message.
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t VectorStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
  */
 template <>
 inline
@@ -141,7 +142,8 @@ inline
 /** \brief Extract a frame ID from the header of a Point message.
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t PointStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
  */
 template <>
 inline
@@ -205,7 +207,8 @@ inline
 /** \brief Extract a frame ID from the header of a Pose message.
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t PoseStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
  */
 template <>
 inline
@@ -306,7 +309,8 @@ const ros::Time& getTimestamp(const geometry_msgs::QuaternionStamped& t)  {retur
 /** \brief Extract a frame ID from the header of a Quaternion message.
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t QuaternionStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
  */
 template <>
 inline
@@ -405,7 +409,8 @@ const ros::Time& getTimestamp(const geometry_msgs::TransformStamped& t)  {return
 /** \brief Extract a frame ID from the header of a Transform message.
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t TransformStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
  */
 template <>
 inline

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -53,7 +53,12 @@ template <>
 inline
 const ros::Time& getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.stamp;}
 
-// method to extract frame id from object
+/** \brief Extract a frame ID from the header of a PointCloud2 message.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * \param t PointCloud2 message to extract the frame ID from.
+ * \return A string containing the frame ID of the message. The lifetime of the
+ * returned reference is bound to the life time of the argument.
+ */
 template <>
 inline
 const std::string& getFrameId(const sensor_msgs::PointCloud2 &p) {return p.header.frame_id;}

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -43,7 +43,12 @@ namespace tf2
 /** PointCloud2    **/
 /********************/
 
-// method to extract timestamp from object
+/** \brief Extract a timestamp from the header of a PointCloud2 message.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * \param t PointCloud2 message to extract the timestamp from.
+ * \return The timestamp of the message. The lifetime of the returned reference
+ * is bound to the life time of the argument.
+ */
 template <>
 inline
 const ros::Time& getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.stamp;}

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -47,7 +47,7 @@ namespace tf2
  * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
  * \param t PointCloud2 message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the life time of the argument.
+ * is bound to the lifetime of the argument.
  */
 template <>
 inline
@@ -57,7 +57,7 @@ const ros::Time& getTimestamp(const sensor_msgs::PointCloud2& p) {return p.heade
  * This function is a specialization of the getFrameId template defined in tf2/convert.h.
  * \param t PointCloud2 message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the life time of the argument.
+ * returned reference is bound to the lifetime of the argument.
  */
 template <>
 inline


### PR DESCRIPTION
This just updates documentation.

For efforts porting tf2 to ROS 2 in https://github.com/ros2/geometry2/pull/14, we need to update the signature to not return const references. To reduce divergence, it's preferable for the signatures to be updated in ROS 1 as well, but I think the conclusion that @tfoote and I came to in our discussion was to leave it as-is for compatibility with external implementations of `tf/convert.h`