### PR TITLE
Find eigen in a nicer way and tf2 msgs deps

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories (src/bt)
 #CPP Libraries
 add_library(tf2 src/cache.cpp src/buffer_core.cpp src/static_cache.cpp)
 target_link_libraries(tf2 ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${console_bridge_LIBRARIES})
-add_dependencies(tf2 tf2_msgs_gencpp)
+add_dependencies(tf2 ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS tf2
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -36,19 +36,19 @@ if(CATKIN_ENABLE_TESTING)
 
 catkin_add_gtest(test_cache_unittest test/cache_unittest.cpp)
 target_link_libraries(test_cache_unittest tf2  ${console_bridge_LIBRARIES})
-add_dependencies(test_cache_unittest tf2_msgs_gencpp)
+add_dependencies(test_cache_unittest ${catkin_EXPORTED_TARGETS})
 
 catkin_add_gtest(test_static_cache_unittest test/static_cache_test.cpp)
 target_link_libraries(test_static_cache_unittest tf2  ${console_bridge_LIBRARIES})
-add_dependencies(test_static_cache_unittest tf2_msgs_gencpp)
+add_dependencies(test_static_cache_unittest ${catkin_EXPORTED_TARGETS})
 
 catkin_add_gtest(test_simple test/simple_tf2_core.cpp)
 target_link_libraries(test_simple tf2  ${console_bridge_LIBRARIES})
-add_dependencies(test_simple tf2_msgs_gencpp)
+add_dependencies(test_simple ${catkin_EXPORTED_TARGETS})
 
 add_executable(speed_test EXCLUDE_FROM_ALL test/speed_test.cpp)
 target_link_libraries(speed_test tf2  ${console_bridge_LIBRARIES})
 add_dependencies(tests speed_test)
-add_dependencies(tests tf2_msgs_gencpp)
+add_dependencies(tests ${catkin_EXPORTED_TARGETS})
 
 endif()

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -7,17 +7,30 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
 )
 
-find_package(Eigen REQUIRED)
-include_directories(${EIGEN_INCLUDE_DIRS})
-add_definitions(${EIGEN_DEFINITIONS})
+# Finding Eigen is somewhat complicated because of our need to support Ubuntu
+# all the way back to saucy.  First we look for the Eigen3 cmake module
+# provided by the libeigen3-dev on newer Ubuntu.  If that fails, then we
+# fall-back to the version provided by cmake_modules, which is a stand-in.
+find_package(Eigen3 QUIET)
+if(NOT EIGEN3_FOUND)
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+endif()
 
-include_directories(${catkin_INCLUDE_DIRS})
+# Note that eigen 3.2 (on Ubuntu Wily) only provides EIGEN3_INCLUDE_DIR,
+# not EIGEN3_INCLUDE_DIRS, so we have to set the latter from the former.
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
-include_directories(include)
+include_directories(include
+                    ${catkin_INCLUDE_DIRS}
+                    ${EIGEN3_INCLUDE_DIRS})
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS eigen)
+  DEPENDS EIGEN3)
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -4,18 +4,34 @@ project(tf2_kdl)
 find_package(orocos_kdl)
 find_package(catkin REQUIRED COMPONENTS cmake_modules tf2 tf2_ros tf2_msgs)
 
-find_package(Eigen REQUIRED)
+# Finding Eigen is somewhat complicated because of our need to support Ubuntu
+# all the way back to saucy.  First we look for the Eigen3 cmake module
+# provided by the libeigen3-dev on newer Ubuntu.  If that fails, then we
+# fall-back to the version provided by cmake_modules, which is a stand-in.
+find_package(Eigen3 QUIET)
+if(NOT EIGEN3_FOUND)
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+endif()
+
+# Note that eigen 3.2 (on Ubuntu Wily) only provides EIGEN3_INCLUDE_DIR,
+# not EIGEN3_INCLUDE_DIRS, so we have to set the latter from the former.
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
+
 
 catkin_package(
-  INCLUDE_DIRS include ${Eigen_INCLUDE_DIRS}
-  DEPENDS Eigen orocos_kdl
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIRS}
+  DEPENDS EIGEN3 orocos_kdl
 )
 
 
 catkin_python_setup()
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 
-include_directories(include ${catkin_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS})
+include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS})
 
 
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -28,17 +28,17 @@ install(PROGRAMS scripts/test.py
 
 if(CATKIN_ENABLE_TESTING)
 
-find_package(catkin REQUIRED COMPONENTS rostest tf2 tf2_ros tf2_msgs)
+  find_package(catkin REQUIRED COMPONENTS rostest tf2 tf2_ros tf2_msgs)
 
-add_executable(test_kdl EXCLUDE_FROM_ALL test/test_tf2_kdl.cpp)
-find_package (Threads)
-target_link_libraries(test_kdl ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${orocos_kdl_LIBRARIES} ${GTEST_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(test_kdl EXCLUDE_FROM_ALL test/test_tf2_kdl.cpp)
+  find_package(Threads)
+  target_link_libraries(test_kdl ${catkin_LIBRARIES} ${GTEST_LIBRARIES} ${orocos_kdl_LIBRARIES} ${GTEST_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
-add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
-add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_python.launch)
+  add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
+  add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test_python.launch)
 
-if(TARGET tests)
-  add_dependencies(tests test_kdl)
-endif()
+  if(TARGET tests)
+    add_dependencies(tests test_kdl)
+  endif()
 
 endif()

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>tf2_kdl</name>
   <version>0.5.15</version>
   <description>
@@ -11,18 +11,15 @@
   <url type="website">http://ros.org/wiki/tf2</url>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
- 
-  <build_depend>cmake_modules</build_depend> <!-- needed for eigen -->
-  <build_depend>eigen</build_depend> <!-- needed by kdl interally -->
-  <build_depend>orocos_kdl</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>
 
-  <run_depend>cmake_modules</run_depend> <!-- needed for eigen -->
-  <run_depend>eigen</run_depend>
-  <run_depend>orocos_kdl</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>tf2_ros</run_depend>
+  <build_depend>cmake_modules</build_depend> <!-- needed for eigen -->
+  <build_depend>eigen</build_depend> <!-- needed by kdl internally -->
+
+  <build_export_depend>eigen</build_export_depend> <!-- needed by kdl internally -->
+
+  <depend>orocos_kdl</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>rostest</test_depend>
 

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -92,7 +92,7 @@ catkin_package(
 link_libraries(${PYTHON_LIBRARIES})
 add_library(tf2_py src/tf2_py.cpp)
 target_link_libraries(tf2_py ${catkin_LIBRARIES})
-add_dependencies(tf2_py tf2_msgs_gencpp)
+add_dependencies(tf2_py ${catkin_EXPORTED_TARGETS})
 
 set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
 set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -47,12 +47,12 @@ add_library(${PROJECT_NAME}
   src/transform_broadcaster.cpp
   src/static_transform_broadcaster.cpp
 )
-add_dependencies(${PROJECT_NAME} tf2_msgs_gencpp)
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 # buffer_server executable
 add_executable(${PROJECT_NAME}_buffer_server src/buffer_server_main.cpp)
-add_dependencies(${PROJECT_NAME}_buffer_server tf2_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_buffer_server ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_buffer_server
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
@@ -66,7 +66,7 @@ set_target_properties(${PROJECT_NAME}_buffer_server
 add_executable(${PROJECT_NAME}_static_transform_publisher
   src/static_transform_broadcaster_program.cpp
 )
-add_dependencies(${PROJECT_NAME}_static_transform_publisher tf2_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_static_transform_publisher ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_static_transform_publisher
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
@@ -111,9 +111,9 @@ find_package(catkin REQUIRED COMPONENTS
 
 # tf2_ros_test_listener
 add_executable(${PROJECT_NAME}_test_listener EXCLUDE_FROM_ALL test/listener_unittest.cpp)
-add_dependencies(${PROJECT_NAME}_test_listener tf2_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_test_listener ${catkin_EXPORTED_TARGETS})
 add_executable(${PROJECT_NAME}_test_time_reset EXCLUDE_FROM_ALL test/time_reset_test.cpp)
-add_dependencies(${PROJECT_NAME}_test_time_reset tf2_msgs_gencpp)
+add_dependencies(${PROJECT_NAME}_test_time_reset ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME}_test_listener
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -3,17 +3,34 @@ project(tf2_sensor_msgs)
 
 find_package(catkin REQUIRED COMPONENTS cmake_modules sensor_msgs tf2_ros tf2)
 find_package(Boost COMPONENTS thread REQUIRED)
-find_package(Eigen)
+
+# Finding Eigen is somewhat complicated because of our need to support Ubuntu
+# all the way back to saucy.  First we look for the Eigen3 cmake module
+# provided by the libeigen3-dev on newer Ubuntu.  If that fails, then we
+# fall-back to the version provided by cmake_modules, which is a stand-in.
+find_package(Eigen3 QUIET)
+if(NOT EIGEN3_FOUND)
+  find_package(cmake_modules REQUIRED)
+  find_package(Eigen REQUIRED)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
+endif()
+
+# Note that eigen 3.2 (on Ubuntu Wily) only provides EIGEN3_INCLUDE_DIR,
+# not EIGEN3_INCLUDE_DIRS, so we have to set the latter from the former.
+if(NOT EIGEN3_INCLUDE_DIRS)
+  set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
+endif()
 
 catkin_package(
    INCLUDE_DIRS include
    CATKIN_DEPENDS sensor_msgs tf2_ros tf2
-   DEPENDS Eigen
+   DEPENDS EIGEN3
 )
 
 
 include_directories(include
    ${catkin_INCLUDE_DIRS}
+   ${EIGEN3_INCLUDE_DIRS}
 )
 
 install(DIRECTORY include/${PROJECT_NAME}/
@@ -26,8 +43,6 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test/test_tf2_sensor_msgs.py)
 
   find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs rostest tf2_ros tf2)
-
-  include_directories(${EIGEN_INCLUDE_DIRS})
 
   add_executable(test_tf2_sensor_msgs_cpp EXCLUDE_FROM_ALL test/test_tf2_sensor_msgs.cpp)
   target_link_libraries(test_tf2_sensor_msgs_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -25,18 +25,17 @@ catkin_python_setup()
 if(CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test/test_tf2_sensor_msgs.py)
 
-find_package(catkin REQUIRED COMPONENTS sensor_msgs rostest tf2_ros tf2)
+  find_package(catkin REQUIRED COMPONENTS sensor_msgs rostest tf2_ros tf2)
 
-include_directories(${EIGEN_INCLUDE_DIRS})
+  include_directories(${EIGEN_INCLUDE_DIRS})
 
-add_executable(test_tf2_sensor_msgs_cpp EXCLUDE_FROM_ALL test/test_tf2_sensor_msgs.cpp)
-target_link_libraries(test_tf2_sensor_msgs_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
+  add_executable(test_tf2_sensor_msgs_cpp EXCLUDE_FROM_ALL test/test_tf2_sensor_msgs.cpp)
+  target_link_libraries(test_tf2_sensor_msgs_cpp ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
 
 
-if(TARGET tests)
-  add_dependencies(tests test_tf2_sensor_msgs_cpp)
-endif()
-add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
-
+  if(TARGET tests)
+    add_dependencies(tests test_tf2_sensor_msgs_cpp)
+  endif()
+  add_rostest(${CMAKE_CURRENT_SOURCE_DIR}/test/test.launch)
 
 endif()

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -25,7 +25,7 @@ catkin_python_setup()
 if(CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test/test_tf2_sensor_msgs.py)
 
-  find_package(catkin REQUIRED COMPONENTS sensor_msgs rostest tf2_ros tf2)
+  find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs rostest tf2_ros tf2)
 
   include_directories(${EIGEN_INCLUDE_DIRS})
 

--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>tf2_sensor_msgs</name>
   <version>0.5.15</version>
   <description>
@@ -9,23 +9,23 @@
   <license>BSD</license>
 
   <url type="website">http://www.ros.org/wiki/tf2_ros</url>
-    
+
   <buildtool_depend version_gte="0.5.6">catkin</buildtool_depend>
 
   <build_depend>cmake_modules</build_depend>
   <build_depend>eigen</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_ros</build_depend>
 
-  <run_depend>cmake_modules</run_depend>
-  <run_depend>eigen</run_depend>
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>tf2_ros</run_depend>
-  <run_depend>tf2</run_depend>
-  <run_depend>python_orocos_kdl</run_depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+
+  <exec_depend>python_orocos_kdl</exec_depend>
+  <exec_depend>rospy</exec_depend>
+
+  <build_export_depend>eigen</build_export_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>geometry_msgs</test_depend>
 
 </package>
 


### PR DESCRIPTION
Augmented #218 by replacing `tf2_msgs_gencpp depencies` by `${catkin_INCLUDE_DIRS}` as suggested [here](http://docs.ros.org/api/catkin/html/howto/format2/cpp_msg_dependencies.html).