### PR TITLE
Store gtest return value as int

### DIFF
--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv){
   t.child_frame_id = "B";
   tf_buffer->setTransform(t, "test");
 
-  bool ret = RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
   delete tf_buffer;
   return ret;
 }

--- a/tf2_bullet/test/test_tf2_bullet.cpp
+++ b/tf2_bullet/test/test_tf2_bullet.cpp
@@ -59,6 +59,6 @@ TEST(TfBullet, ConvertVector)
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
 
-  bool ret = RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
   return ret;
 }

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -142,7 +142,7 @@ int main(int argc, char **argv){
   t.child_frame_id = "B";
   tf_buffer->setTransform(t, "test");
 
-  bool ret = RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
   delete tf_buffer;
   return ret;
 }

--- a/tf2_kdl/test/test_tf2_kdl.cpp
+++ b/tf2_kdl/test/test_tf2_kdl.cpp
@@ -125,7 +125,7 @@ int main(int argc, char **argv){
   t.child_frame_id = "B";
   tf_buffer->setTransform(t, "test");
 
-  bool retval = RUN_ALL_TESTS();
+  int retval = RUN_ALL_TESTS();
   delete tf_buffer;
   return retval;
 }

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv){
   t.child_frame_id = "B";
   tf_buffer->setTransform(t, "test");
 
-  bool ret = RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
   delete tf_buffer;
   return ret;
 }


### PR DESCRIPTION
This is to prevent `'int': forcing value to bool 'true' or 'false' (performance warning)` warnings (e.g. [this ROS 2 build](http://ci.ros2.org/job/ci_windows/2666/warnings41Result/new/))