### PR TITLE
add RPY parameter handling

### DIFF
--- a/tf2_ros/doc/index.rst
+++ b/tf2_ros/doc/index.rst
@@ -3,14 +3,51 @@ tf2_ros Overview
 
 This is the Python API reference for the tf2_ros package.
 
-To broadcast transforms using ROS:
+To broadcast transforms using ROS
+------------------------------------------------
+*Adding a TransformBroadcaster to an existing Python node*
+
 - Call :meth:`rospy.init` to initialize a node.
 - Construct a :class:`tf2_ros.TransformBroadcaster`.
 - Pass a :class:`geometry_msgs.TransformStamped` message to :meth:`tf2_ros.TransformBroadcaster.sendTransform`.
 
     - Alternatively, pass a vector of :class:`geometry_msgs.TransformStamped` messages.
 
-To listen for transforms using ROS:
+*Launching a dedicated static_transform_publisher node*
+
+A node dedicated to publish a static transformation can be launched directly from a launch file using the following syntax.
+
+In the launch file:
+
+| <node pkg="tf2_ros" type="static_transform_publisher" name="publisher_name" args="tf_frame_to_be_published_parameter_name"/>
+
+
+The tf_frame_to_be_published_parameter_name can be defined in a yaml file using the following syntax:
+
+- RPY
+    | tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
+    | tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
+    | tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/rotation/R: deg(0.0)
+    | tf_frame_to_be_published_parameter_name/transform/rotation/P: deg(0.0)
+    | tf_frame_to_be_published_parameter_name/transform/rotation/Y: deg(0.0)
+
+- Quaternions
+    | tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
+    | tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
+    | tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/rotation/x: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/rotation/y: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/rotation/z: 0.0
+    | tf_frame_to_be_published_parameter_name/transform/rotation/w: 1.0
+
+
+To listen for transforms using ROS
+------------------------------------------------
 - Construct an instance of a class that implements :class:`tf2_ros.BufferInterface`.
 
     - :class:`tf2_ros.Buffer` is the standard implementation which offers a tf2_frames service that can respond to requests with a :class:`tf2_msgs.FrameGraph`.
@@ -24,6 +61,8 @@ To listen for transforms using ROS:
     - Or, check if a transform is available with :meth:`tf2_ros.BufferInterface.can_transform`.
     - Then, call :meth:`tf2_ros.BufferInterface.lookup_transform` to get the transform between two frames.
 
+More information
+----------------
 For more information, see the tf2 tutorials: http://wiki.ros.org/tf2/Tutorials
 
 Or, get an `overview`_ of data type conversion methods in geometry_experimental packages.

--- a/tf2_ros/doc/mainpage.dox
+++ b/tf2_ros/doc/mainpage.dox
@@ -6,14 +6,49 @@
 
 \section codeapi Code API
 
-To broadcast transforms using ROS:
+\subsection To broadcast transforms using ROS
+\subsubsection Adding a TransformBroadcaster to an existing Python node
 - Call ros::init() to initialize a node.
 - Construct a tf2_ros::TransformBroadcaster.
 - Pass a geometry_msgs::TransformStamped message to tf2_ros::TransformBroadcaster::sendTransform().
   - Alternatively, pass a vector of geometry_msgs::TransformStamped messages.
 - Use tf2_ros::StaticTransformBroadcaster for "latching" behavior when transforms that are not expected to change.
 
-To listen for transforms using ROS:
+\subsubsection Launching a dedicated static_transform_publisher node
+A node dedicated to publish a static transformation can be launched directly from a launch file using the following syntax.
+
+In the launch file:
+\code
+<node pkg="tf2_ros" type="static_transform_publisher" name="publisher_name" args="tf_frame_to_be_published_parameter_name"/>
+\endcode
+
+The tf_frame_to_be_published_parameter_name can be defined in a yaml file using the following syntax:
+- RPY
+\code
+    tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
+    tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
+    tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
+    tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
+    tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
+    tf_frame_to_be_published_parameter_name/transform/rotation/R: deg(0.0)
+    tf_frame_to_be_published_parameter_name/transform/rotation/P: deg(0.0)
+    tf_frame_to_be_published_parameter_name/transform/rotation/Y: deg(0.0)
+\endcode
+- Quaternions
+\code
+    tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
+    tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
+    tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
+    tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
+    tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
+    tf_frame_to_be_published_parameter_name/transform/rotation/x: 0.0
+    tf_frame_to_be_published_parameter_name/transform/rotation/y: 0.0
+    tf_frame_to_be_published_parameter_name/transform/rotation/z: 0.0
+    tf_frame_to_be_published_parameter_name/transform/rotation/w: 1.0
+\endcode
+
+
+\subsection To listen for transforms using ROS
 - Construct an instance of a class that implements tf2_ros::BufferInterface.
   - tf2_ros::Buffer is the standard implementation which offers a tf2_frames service that can respond to requests with a tf2_msgs::FrameGraph.
   - tf2_ros::BufferClient uses an actionlib::SimpleActionClient to wait for the requested transform to become available.
@@ -27,7 +62,7 @@ To listen for transforms using ROS:
 - Construct a tf2_ros::MessageFilter with the TransformListener to apply a transformation to incoming frames.
   - This is especially useful when streaming sensor data.
 
-List of exceptions thrown in this library:
+\subsection List of exceptions thrown in this library
 - tf2::LookupException
 - tf2::ConnectivityException
 - tf2::ExtrapolationException

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -116,22 +116,12 @@ int main(int argc, char ** argv)
 
     // Check that all required members are present & of the right type.
     if (validateXmlRpcTfQuaternion(tf_data)) {
-      msg.transform.translation.x = (double) tf_data["transform"]["translation"]["x"];
-      msg.transform.translation.y = (double) tf_data["transform"]["translation"]["y"];
-      msg.transform.translation.z = (double) tf_data["transform"]["translation"]["z"];
       msg.transform.rotation.x = (double) tf_data["transform"]["rotation"]["x"];
       msg.transform.rotation.y = (double) tf_data["transform"]["rotation"]["y"];
       msg.transform.rotation.z = (double) tf_data["transform"]["rotation"]["z"];
       msg.transform.rotation.w = (double) tf_data["transform"]["rotation"]["w"];
-      msg.header.stamp = ros::Time::now();
-      msg.header.frame_id = (std::string) tf_data["header"]["frame_id"];
-      msg.child_frame_id = (std::string) tf_data["child_frame_id"];
     }
     else if (validateXmlRpcTfRPY(tf_data)) {
-      msg.transform.translation.x = (double) tf_data["transform"]["translation"]["x"];
-      msg.transform.translation.y = (double) tf_data["transform"]["translation"]["y"];
-      msg.transform.translation.z = (double) tf_data["transform"]["translation"]["z"];
-
       tf2::Quaternion quat;
       quat.setRPY((double) tf_data["transform"]["rotation"]["R"],
                   (double) tf_data["transform"]["rotation"]["P"],
@@ -141,17 +131,17 @@ int main(int argc, char ** argv)
       msg.transform.rotation.y = quat.y();
       msg.transform.rotation.z = quat.z();
       msg.transform.rotation.w = quat.w();
-
-      msg.header.stamp = ros::Time::now();
-      msg.header.frame_id = (std::string) tf_data["header"]["frame_id"];
-      msg.child_frame_id = (std::string) tf_data["child_frame_id"];
     }
     else {
       ROS_FATAL_STREAM("Could not validate XmlRpcC for TF data: " << tf_data);
       return -1;
     }
-
-
+    msg.transform.translation.x = (double) tf_data["transform"]["translation"]["x"];
+    msg.transform.translation.y = (double) tf_data["transform"]["translation"]["y"];
+    msg.transform.translation.z = (double) tf_data["transform"]["translation"]["z"];
+    msg.header.stamp = ros::Time::now();
+    msg.header.frame_id = (std::string) tf_data["header"]["frame_id"];
+    msg.child_frame_id = (std::string) tf_data["child_frame_id"];
   }
   else
   {


### PR DESCRIPTION
This PR allows a tf frame to be published to be defined in a yaml file using the RPY syntax:
```

tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
tf_frame_to_be_published_parameter_name/transform/rotation/R: deg(0.0)
tf_frame_to_be_published_parameter_name/transform/rotation/P: deg(0.0)
tf_frame_to_be_published_parameter_name/transform/rotation/Y: deg(0.0)
```

Next to the existing syntax with quaternions:
```

tf_frame_to_be_published_parameter_name/header/frame_id: "parent_frame_id"
tf_frame_to_be_published_parameter_name/child_frame_id: "child_frame_id"
tf_frame_to_be_published_parameter_name/transform/translation/x: 0.0
tf_frame_to_be_published_parameter_name/transform/translation/y: 0.0
tf_frame_to_be_published_parameter_name/transform/translation/z: 0.0
tf_frame_to_be_published_parameter_name/transform/rotation/x: 0.0
tf_frame_to_be_published_parameter_name/transform/rotation/y: 0.0
tf_frame_to_be_published_parameter_name/transform/rotation/z: 0.0
tf_frame_to_be_published_parameter_name/transform/rotation/w: 1.0
```