### PR TITLE
Log jump duration on backwards time jump detection

### DIFF
--- a/tf2_ros/src/transform_listener.cpp
+++ b/tf2_ros/src/transform_listener.cpp
@@ -103,7 +103,7 @@ void TransformListener::subscription_callback_impl(const ros::MessageEvent<tf2_m
 {
   ros::Time now = ros::Time::now();
   if(now < last_update_){
-    ROS_WARN("Detected jump back in time. Clearing TF buffer.");
+    ROS_WARN_STREAM("Detected jump back in time of " << (last_update_ - now).toSec() << "s. Clearing TF buffer.");
     buffer_.clear();
   }
   last_update_ = now;


### PR DESCRIPTION
TransformListener prints out a warning when ROS time jumps backwards.
This commit modifies the log line to include the amount of time that the jump had.