### PR TITLE
Copy transform before altering it in do_transform_vector3 [issue 233]

### DIFF
--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -31,6 +31,7 @@ from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped
 import PyKDL
 import rospy
 import tf2_ros
+import copy
 
 def to_msg_msg(msg):
     return msg
@@ -68,6 +69,7 @@ tf2_ros.TransformRegistration().add(PointStamped, do_transform_point)
 
 # Vector3Stamped
 def do_transform_vector3(vector3, transform):
+    transform = copy.deepcopy(transform)
     transform.transform.translation.x = 0;
     transform.transform.translation.y = 0;
     transform.transform.translation.z = 0;


### PR DESCRIPTION
Fixes #233, where a transform passed to do_transform_vector3 was changes inside the function and made useless for later transforms.