### PR TITLE
fix return value to prevent warnings on windows

### DIFF
--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -162,6 +162,5 @@ TEST(TfEigen, ConvertTransform)
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
 
-  bool ret = RUN_ALL_TESTS();
-  return ret;
+  return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Windows complain if we return a bool instead of an int here