### PR TITLE
Make tf2_py python3 compatible again

### DIFF
--- a/test_tf2/test/test_convert.py
+++ b/test_tf2/test/test_convert.py
@@ -34,6 +34,9 @@
 #* 
 #* Author: Eitan Marder-Eppstein
 #***********************************************************
+
+from __future__ import print_function
+
 PKG = 'test_tf2'
 import roslib; roslib.load_manifest(PKG)
 
@@ -51,15 +54,15 @@ import PyKDL
 class TestConvert(unittest.TestCase):
     def test_convert(self):
         p = tf2_ros.Stamped(PyKDL.Vector(1, 2, 3), rospy.Time(), 'my_frame')
-        print p
+        print(p)
         msg = tf2_ros.convert(p, PointStamped) 
-        print msg
+        print(msg)
         p2 = tf2_ros.convert(msg, PyKDL.Vector)
-        print p2
+        print(p2)
         p2[0] = 100
-        print p
-        print p2
-        print p2.header
+        print(p)
+        print(p2)
+        print(p2.header)
 
 if __name__ == '__main__':
     import rostest

--- a/tf2_kdl/scripts/test.py
+++ b/tf2_kdl/scripts/test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import unittest
 import rospy
 import PyKDL
@@ -32,7 +34,7 @@ class KDLConversions(unittest.TestCase):
 
         f = PyKDL.Frame(PyKDL.Rotation.RPY(1,2,3), PyKDL.Vector(1,2,3))
         out = b.transform(tf2_ros.Stamped(f, rospy.Time(2), 'a'), 'b')
-        print out
+        print(out)
         self.assertEqual(out.p.x(), 0)
         self.assertEqual(out.p.y(), -2)
         self.assertEqual(out.p.z(), -3)

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -536,7 +536,7 @@ static PyObject *_allFramesAsDot(PyObject *self, PyObject *args, PyObject *kw)
   ros::Time time;
   if (!PyArg_ParseTupleAndKeywords(args, kw, "|O&", (char**)keywords, rostime_converter, &time))
     return NULL;
-  return PyString_FromString(bc->_allFramesAsDot(time.toSec()).c_str());
+  return stringToPython(bc->_allFramesAsDot(time.toSec()));
 }
 
 

--- a/tf2_ros/src/tf2_ros/buffer_interface.py
+++ b/tf2_ros/src/tf2_ros/buffer_interface.py
@@ -27,6 +27,8 @@
 
 # author: Wim Meeussen
 
+from __future__ import print_function
+
 import roslib; roslib.load_manifest('tf2_ros')
 import rospy
 import tf2_py as tf2
@@ -192,7 +194,7 @@ class TransformRegistration():
     __type_map = {}
     
     def print_me(self):
-        print TransformRegistration.__type_map
+        print(TransformRegistration.__type_map)
 
     def add(self, key, callback):
         TransformRegistration.__type_map[key] = callback
@@ -240,14 +242,14 @@ def convert(a, b_type):
     #check if an efficient conversion function between the types exists
     try:
         f = c.get_convert((type(a), b_type))
-        print "efficient copy"
+        print("efficient copy")
         return f(a)
     except TypeException:
         if type(a) == b_type:
-            print "deep copy"
+            print("deep copy")
             return deepcopy(a)
 
         f_to = c.get_to_msg(type(a))
         f_from = c.get_from_msg(b_type)
-        print "message copy"
+        print("message copy")
         return f_from(f_to(a))

--- a/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
+++ b/tf2_sensor_msgs/test/test_tf2_sensor_msgs.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import unittest
 import struct
 import tf2_sensor_msgs


### PR DESCRIPTION
120a532 reintroduced usage of `PyString_FromString`, which should be `stringToPython` from `python_compat.h` (which actually calls `PyUnicode_FromString` when compiled for python3). This PR does that so `tf2_py` can be compiled for python3 again.

It would be nice to have a python3 platform on CI somewhere to prevent this from accidentally happening again. I'm guessing that isn't as straightforward as one might hope though.

Additionally, this PR changes some `print` statements to `print` functions in assorted python scripts for python 3 compatibility.