### PR TITLE
Speed-up TimeCache search for large cache time.

### DIFF
--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -34,7 +34,7 @@
 
 #include "transform_storage.h"
 
-#include <list>
+#include <deque>
 
 #include <sstream>
 
@@ -116,7 +116,7 @@ class TimeCache : public TimeCacheInterface
   
 
 private:
-  typedef std::list<TransformStorage> L_TransformStorage;
+  typedef std::deque<TransformStorage> L_TransformStorage;
   L_TransformStorage storage_;
 
   ros::Duration max_storage_time_;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -93,6 +93,11 @@ void createExtrapolationException3(ros::Time t0, ros::Time t1, std::string* erro
 }
 } // namespace cache
 
+bool operator>(const TransformStorage& lhs, const TransformStorage& rhs)
+{
+  return lhs.stamp_ > rhs.stamp_;
+}
+
 uint8_t TimeCache::findClosest(TransformStorage*& one, TransformStorage*& two, ros::Time target_time, std::string* error_str)
 {
   //No values stored
@@ -151,13 +156,14 @@ uint8_t TimeCache::findClosest(TransformStorage*& one, TransformStorage*& two, r
 
   //At least 2 values stored
   //Find the first value less than the target value
-  L_TransformStorage::iterator storage_it = storage_.begin();
-  while(storage_it != storage_.end())
-  {
-    if (storage_it->stamp_ <= target_time)
-      break;
-    storage_it++;
-  }
+  L_TransformStorage::iterator storage_it;
+  TransformStorage storage_target_time;
+  storage_target_time.stamp_ = target_time;
+
+  storage_it = std::lower_bound(
+      storage_.begin(),
+      storage_.end(),
+      storage_target_time, std::greater<TransformStorage>());
 
   //Finally the case were somewhere in the middle  Guarenteed no extrapolation :-)
   one = &*(storage_it); //Older

--- a/tf2/test/speed_test.cpp
+++ b/tf2/test/speed_test.cpp
@@ -41,6 +41,13 @@ int main(int argc, char** argv)
   {
     num_levels = boost::lexical_cast<uint32_t>(argv[1]);
   }
+  double time_interval = 1.0;
+  if (argc > 2)
+  {
+    time_interval = boost::lexical_cast<double>(argv[2]);
+  }
+
+  console_bridge::setLogLevel(console_bridge::CONSOLE_BRIDGE_LOG_INFO);
 
   tf2::BufferCore bc;
   geometry_msgs::TransformStamped t;
@@ -53,9 +60,9 @@ int main(int argc, char** argv)
   t.header.stamp = ros::Time(2);
   bc.setTransform(t, "me");
 
-  for (uint32_t i = 1; i < num_levels/2; ++i)
+  for (uint32_t i = 1; i < num_levels / 2; ++i)
   {
-    for (uint32_t j = 1; j < 3; ++j)
+    for (double j = time_interval; j < 2.0 + time_interval; j += time_interval)
     {
       std::stringstream parent_ss;
       parent_ss << (i - 1);
@@ -80,7 +87,7 @@ int main(int argc, char** argv)
 
   for (uint32_t i = num_levels/2 + 1; i < num_levels; ++i)
   {
-    for (uint32_t j = 1; j < 3; ++j)
+    for (double j = time_interval; j < 2.0 + time_interval; j += time_interval)
     {
       std::stringstream parent_ss;
       parent_ss << (i - 1);
@@ -102,7 +109,7 @@ int main(int argc, char** argv)
   geometry_msgs::TransformStamped out_t;
 
   const uint32_t count = 1000000;
-  logInform("Doing %d %d-level tests", count, num_levels);
+  logInform("Doing %d %d-level %lf-interval tests", count, num_levels, time_interval);
 
 #if 01
   {


### PR DESCRIPTION
The current implementation of TimeCache::findClosest is linear search,
costing pretty much for buffers with large cache time.
This commit improves search cost of findClosest by using binary search.