### PR TITLE
Fixed for cases of non-standard python install

### DIFF
--- a/tf2_tools/scripts/view_frames.py
+++ b/tf2_tools/scripts/view_frames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # Copyright (c) 2008, Willow Garage, Inc.
 # All rights reserved.
 # 


### PR DESCRIPTION
This fixes an issue where for instance on mac where homebrewed python installs would result in a segmentation fault since it was using the system version of python with homebrewed extensions