### PR TITLE
allFrameAsYaml consistently outputting a dict

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1158,7 +1158,7 @@ std::string BufferCore::allFramesAsYAML(double current_time) const
   TransformStorage temp;
 
   if (frames_.size() ==1)
-    mstream <<"[]";
+    mstream <<"{}";
 
   mstream.precision(3);
   mstream.setf(std::ios::fixed,std::ios::floatfield);


### PR DESCRIPTION
It was conditionally outputting a list in the case of an empty list. There was a workaround to resolve this downstream at ros/geometry#153