### PR TITLE
PyString to PyBytes fix when using Python 3

### DIFF
--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -5,6 +5,10 @@
 
 #include "python_compat.h"
 
+#if PY_VERSION_HEX >= 0x03000000
+#define PyString_FromString PyBytes_FromString
+#endif
+
 // Run x (a tf method, catching TF's exceptions and reraising them as Python exceptions)
 //
 #define WRAP(x) \


### PR DESCRIPTION
PyString has been renamed to PyBytes in Python 3.x, this change remains backwards compatible with Python 2.

This fixes the issue in #274