### PR TITLE
Added WrenchStamped transformation

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -42,6 +42,8 @@
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/Wrench.h>
+#include <geometry_msgs/WrenchStamped.h>
 #include <kdl/frames.hpp>
 
 namespace tf2
@@ -975,6 +977,77 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+
+
+/**********************/
+/*** WrenchStamped ****/
+/**********************/
+template <>
+inline
+const ros::Time& getTimestamp(const geometry_msgs::WrenchStamped& t) {return t.header.stamp;}
+
+
+template <>
+inline
+const std::string& getFrameId(const geometry_msgs::WrenchStamped& t) {return t.header.frame_id;}
+
+
+inline
+geometry_msgs::WrenchStamped toMsg(const geometry_msgs::WrenchStamped& in)
+{
+  return in;
+}
+
+inline
+void fromMsg(const geometry_msgs::WrenchStamped& msg, geometry_msgs::WrenchStamped& out)
+{
+  out = msg;
+}
+
+
+inline
+geometry_msgs::WrenchStamped toMsg(const tf2::Stamped<std::array<tf2::Vector3, 2>>& in, geometry_msgs::WrenchStamped & out)
+{
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  out.wrench.force = toMsg(in[0]);
+  out.wrench.torque = toMsg(in[1]);
+  return out;
+}
+
+
+inline
+void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<std::array<tf2::Vector3, 2>>& out)
+{
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  tf2::Vector3 tmp;
+  fromMsg(msg.wrench.force, tmp);
+  tf2::Vector3 tmp1;
+  fromMsg(msg.wrench.torque, tmp1);
+  std::array<tf2::Vector3, 2> tmp_array;
+  tmp_array[0] = tmp;
+  tmp_array[1] = tmp1;
+  out.setData(tmp);
+}
+
+template<>
+inline
+void doTransform(const geometry_msgs::Wrench& t_in, geometry_msgs::Wrench& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  doTransform(t_in.force, t_out.force, transform);
+  doTransform(t_in.torque, t_out.torque, transform);
+}
+
+
+template<>
+inline
+void doTransform(const geometry_msgs::WrenchStamped& t_in, geometry_msgs::WrenchStamped& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  doTransform(t_in.wrench, t_out.wrench, transform);
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
 
 } // namespace
 

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -1028,7 +1028,7 @@ void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<std::array<tf
   std::array<tf2::Vector3, 2> tmp_array;
   tmp_array[0] = tmp;
   tmp_array[1] = tmp1;
-  out.setData(tmp);
+  out.setData(tmp_array);
 }
 
 template<>

--- a/tf2_geometry_msgs/scripts/test.py
+++ b/tf2_geometry_msgs/scripts/test.py
@@ -5,7 +5,7 @@ import rospy
 import PyKDL
 import tf2_ros
 import tf2_geometry_msgs
-from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped
+from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, WrenchStamped
 
 class GeometryMsgs(unittest.TestCase):
     def test_transform(self):
@@ -77,6 +77,22 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.vector.x, -1)
         self.assertEqual(out.vector.y, 0)
         self.assertEqual(out.vector.z, 0)
+
+        v = WrenchStamped()
+        v.wrench.force.x = 1
+        v.wrench.force.y = 0
+        v.wrench.force.z = 0
+        v.wrench.torque.x = 1
+        v.wrench.torque.y = 0
+        v.wrench.torque.z = 0
+
+        out = tf2_geometry_msgs.do_transform_wrench(v, t)
+        self.assertEqual(out.wrench.force.x, -1)
+        self.assertEqual(out.wrench.force.y, 0)
+        self.assertEqual(out.wrench.force.z, 0)
+        self.assertEqual(out.wrench.torque.x, -1)
+        self.assertEqual(out.wrench.torque.y, 0)
+        self.assertEqual(out.wrench.torque.z, 0)
 
 if __name__ == '__main__':
     import rosunit

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -27,7 +27,7 @@
 
 # author: Wim Meeussen
 
-from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped
+from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped, WrenchStamped
 import PyKDL
 import rospy
 import tf2_ros
@@ -95,3 +95,16 @@ def do_transform_pose(pose, transform):
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose)
+
+# WrenchStamped
+def do_transform_wrench(wrench, transform):
+    force = Vector3Stamped()
+    torque = Vector3Stamped()
+    force.vector = wrench.wrench.force
+    torque.vector = wrench.wrench.torque
+    res = WrenchStamped()
+    res.wrench.force = do_transform_vector3(force, transform).vector
+    res.wrench.torque = do_transform_vector3(torque, transform).vector
+    res.header = transform.header
+    return res
+tf2_ros.TransformRegistration().add(WrenchStamped, do_transform_wrench)

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -325,6 +325,32 @@ TEST(TfGeometry, doTransformVector3)
   EXPECT_NEAR(res.z, 3, EPS);
 }
 
+TEST(TfGeometry, doTransformWrench)
+{
+ geometry_msgs::Wrench v1, res;
+ v1.force.x = 2;
+ v1.force.y = 1;
+ v1.force.z = 3;
+ v1.torque.x = 2;
+ v1.torque.y = 1;
+ v1.torque.z = 3;
+
+ geometry_msgs::TransformStamped trafo;
+ trafo.transform.translation.x = -1;
+ trafo.transform.translation.y = 2;
+ trafo.transform.translation.z = -3;
+ trafo.transform.rotation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0,0,1), -M_PI / 2.0));
+
+ tf2::doTransform(v1, res, trafo);
+ EXPECT_NEAR(res.force.x, 1, EPS);
+ EXPECT_NEAR(res.force.y, -2, EPS);
+ EXPECT_NEAR(res.force.z, 3, EPS);
+
+ EXPECT_NEAR(res.torque.x, 1, EPS);
+ EXPECT_NEAR(res.torque.y, -2, EPS);
+ EXPECT_NEAR(res.torque.z, 3, EPS);
+}
+
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test");


### PR DESCRIPTION
Hi,

we added WranchStamped transformation we are using very often in Force-Control context. We didn't start new package as proposed in the [ROS-tutorial](https://wiki.ros.org/tf2/Tutorials/Create%20Data%20Conversion%20Package%20%28C%2B%2B%29) since I believe it should be placed with other geometry_msgs.

Should I create PRs also for kinetic?