### PR TITLE
Changed access to Vector to prevent memory leak

### DIFF
--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -88,9 +88,9 @@ def do_transform_pose(pose, transform):
                                                                           pose.pose.orientation.z, pose.pose.orientation.w),
                                                 PyKDL.Vector(pose.pose.position.x, pose.pose.position.y, pose.pose.position.z))
     res = PoseStamped()
-    res.pose.position.x = f.p[0]
-    res.pose.position.y = f.p[1]
-    res.pose.position.z = f.p[2]
+    res.pose.position.x = f.p.x()
+    res.pose.position.y = f.p.y()
+    res.pose.position.z = f.p.z()
     (res.pose.orientation.x, res.pose.orientation.y, res.pose.orientation.z, res.pose.orientation.w) = f.M.GetQuaternion()
     res.header = transform.header
     return res

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -88,9 +88,9 @@ def do_transform_pose(pose, transform):
                                                                           pose.pose.orientation.z, pose.pose.orientation.w),
                                                 PyKDL.Vector(pose.pose.position.x, pose.pose.position.y, pose.pose.position.z))
     res = PoseStamped()
-    res.pose.position.x = f.p.x()
-    res.pose.position.y = f.p.y()
-    res.pose.position.z = f.p.z()
+    res.pose.position.x = f[(0, 3)]
+    res.pose.position.y = f[(1, 3)]
+    res.pose.position.z = f[(2, 3)]
     (res.pose.orientation.x, res.pose.orientation.y, res.pose.orientation.z, res.pose.orientation.w) = f.M.GetQuaternion()
     res.header = transform.header
     return res


### PR DESCRIPTION
Fixes #304 
Not sure what exactly causes the issue but I think it's related to SIP internals:
https://github.com/orocos/orocos_kinematics_dynamics/blob/master/python_orocos_kdl/PyKDL/frames.sip#L51
Anyway, with this workaround, the issue does not appear and it should basically do the same.