### PR TITLE
preserve constness of const argument to avoid warnings

### DIFF
--- a/tf2/include/tf2/LinearMath/Vector3.h
+++ b/tf2/include/tf2/LinearMath/Vector3.h
@@ -621,7 +621,7 @@ public:
 TF2SIMD_FORCE_INLINE void	tf2SwapScalarEndian(const tf2Scalar& sourceVal, tf2Scalar& destVal)
 {
 	unsigned char* dest = (unsigned char*) &destVal;
-	unsigned char* src  = (unsigned char*) &sourceVal;
+	const unsigned char* src  = (const unsigned char*) &sourceVal;
 	dest[0] = src[7];
     dest[1] = src[6];
     dest[2] = src[5];


### PR DESCRIPTION
Replicating ros/geometry#167