### PR TITLE
Backport content to Kinetic from Melodic branch for the 0.6 branch

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -1,11 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 
+project(test_tf2)
+
 if(NOT CATKIN_ENABLE_TESTING)
   return()
 endif()
-
-project(test_tf2)
-
 
 find_package(catkin REQUIRED COMPONENTS rosconsole roscpp rostest tf tf2 tf2_bullet tf2_ros tf2_geometry_msgs tf2_kdl tf2_msgs)
 find_package(Boost REQUIRED COMPONENTS thread)

--- a/test_tf2/test/test_tf2_bullet.launch
+++ b/test_tf2/test/test_tf2_bullet.launch
@@ -1,3 +1,3 @@
 <launch>
-  <test test-name="test_tf_bullet" pkg="tf2_bullet" type="test_bullet" time-limit="120" />
+  <test test-name="test_tf2_bullet" pkg="test_tf2" type="test_tf2_bullet" time-limit="120" />
 </launch>

--- a/tf2/include/tf2/LinearMath/Vector3.h
+++ b/tf2/include/tf2/LinearMath/Vector3.h
@@ -621,7 +621,7 @@ public:
 TF2SIMD_FORCE_INLINE void	tf2SwapScalarEndian(const tf2Scalar& sourceVal, tf2Scalar& destVal)
 {
 	unsigned char* dest = (unsigned char*) &destVal;
-	unsigned char* src  = (unsigned char*) &sourceVal;
+	const unsigned char* src  = (const unsigned char*) &sourceVal;
 	dest[0] = src[7];
     dest[1] = src[6];
     dest[2] = src[5];

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -143,7 +143,7 @@ public:
 		    const std::string& source_frame, const ros::Time& source_time,
 		    const std::string& fixed_frame) const;
   
-  /** \brief Lookup the twist of the tracking_frame with respect to the observation frame in the reference_frame using the reference point
+  /* \brief Lookup the twist of the tracking_frame with respect to the observation frame in the reference_frame using the reference point
    * \param tracking_frame The frame to track
    * \param observation_frame The frame from which to measure the twist
    * \param reference_frame The reference frame in which to express the twist
@@ -169,7 +169,7 @@ public:
 		const tf::Point & reference_point, const std::string& reference_point_frame, 
 		const ros::Time& time, const ros::Duration& averaging_interval) const;
   */
-  /** \brief lookup the twist of the tracking frame with respect to the observational frame 
+  /* \brief lookup the twist of the tracking frame with respect to the observational frame
    * 
    * This is a simplified version of
    * lookupTwist with it assumed that the reference point is the

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -125,6 +125,33 @@ void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out)
   out.z() = msg.z;
 }
 
+/** \brief Convert an Eigen Vector3d type to a Vector3 message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The Eigen Vector3d to convert.
+ * \return The vector converted to a Vector3 message.
+ */
+inline
+geometry_msgs::Vector3& toMsg(const Eigen::Vector3d& in, geometry_msgs::Vector3& out)
+{
+  out.x = in.x();
+  out.y = in.y();
+  out.z = in.z();
+  return out;
+}
+
+/** \brief Convert a Vector3 message type to a Eigen-specific Vector3d type.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * \param msg The Vector3 message to convert.
+ * \param out The vector converted to a Eigen Vector3d.
+ */
+inline
+void fromMsg(const geometry_msgs::Vector3& msg, Eigen::Vector3d& out)
+{
+  out.x() = msg.x;
+  out.y() = msg.y;
+  out.z() = msg.z;
+}
+
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.
  * \param t_in The vector to transform, as a timestamped Eigen Vector3d data type.
@@ -321,10 +348,10 @@ geometry_msgs::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
   return msg;
 }
 
-/** \brief Convert a Pose message transform type to a Eigen Affine3d.
+/** \brief Convert a Twist message transform type to a Eigen 6x1 Matrix.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
  * \param msg The Twist message to convert.
- * \param out The twist converted to a Eigen Matrix.
+ * \param out The twist converted to a Eigen 6x1 Matrix.
  */
 inline
 void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -42,6 +42,8 @@
 #include <geometry_msgs/Pose.h>
 #include <geometry_msgs/PoseStamped.h>
 #include <geometry_msgs/PoseWithCovarianceStamped.h>
+#include <geometry_msgs/Wrench.h>
+#include <geometry_msgs/WrenchStamped.h>
 #include <kdl/frames.hpp>
 
 namespace tf2
@@ -975,6 +977,77 @@ inline
     t_out.header.stamp = transform.header.stamp;
     t_out.header.frame_id = transform.header.frame_id;
   }
+
+
+/**********************/
+/*** WrenchStamped ****/
+/**********************/
+template <>
+inline
+const ros::Time& getTimestamp(const geometry_msgs::WrenchStamped& t) {return t.header.stamp;}
+
+
+template <>
+inline
+const std::string& getFrameId(const geometry_msgs::WrenchStamped& t) {return t.header.frame_id;}
+
+
+inline
+geometry_msgs::WrenchStamped toMsg(const geometry_msgs::WrenchStamped& in)
+{
+  return in;
+}
+
+inline
+void fromMsg(const geometry_msgs::WrenchStamped& msg, geometry_msgs::WrenchStamped& out)
+{
+  out = msg;
+}
+
+
+inline
+geometry_msgs::WrenchStamped toMsg(const tf2::Stamped<std::array<tf2::Vector3, 2>>& in, geometry_msgs::WrenchStamped & out)
+{
+  out.header.stamp = in.stamp_;
+  out.header.frame_id = in.frame_id_;
+  out.wrench.force = toMsg(in[0]);
+  out.wrench.torque = toMsg(in[1]);
+  return out;
+}
+
+
+inline
+void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<std::array<tf2::Vector3, 2>>& out)
+{
+  out.stamp_ = msg.header.stamp;
+  out.frame_id_ = msg.header.frame_id;
+  tf2::Vector3 tmp;
+  fromMsg(msg.wrench.force, tmp);
+  tf2::Vector3 tmp1;
+  fromMsg(msg.wrench.torque, tmp1);
+  std::array<tf2::Vector3, 2> tmp_array;
+  tmp_array[0] = tmp;
+  tmp_array[1] = tmp1;
+  out.setData(tmp_array);
+}
+
+template<>
+inline
+void doTransform(const geometry_msgs::Wrench& t_in, geometry_msgs::Wrench& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  doTransform(t_in.force, t_out.force, transform);
+  doTransform(t_in.torque, t_out.torque, transform);
+}
+
+
+template<>
+inline
+void doTransform(const geometry_msgs::WrenchStamped& t_in, geometry_msgs::WrenchStamped& t_out, const geometry_msgs::TransformStamped& transform)
+{
+  doTransform(t_in.wrench, t_out.wrench, transform);
+  t_out.header.stamp = transform.header.stamp;
+  t_out.header.frame_id = transform.header.frame_id;
+}
 
 } // namespace
 

--- a/tf2_geometry_msgs/scripts/test.py
+++ b/tf2_geometry_msgs/scripts/test.py
@@ -5,7 +5,7 @@ import rospy
 import PyKDL
 import tf2_ros
 import tf2_geometry_msgs
-from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped
+from geometry_msgs.msg import TransformStamped, PointStamped, Vector3Stamped, PoseStamped, WrenchStamped
 
 class GeometryMsgs(unittest.TestCase):
     def test_transform(self):
@@ -77,6 +77,22 @@ class GeometryMsgs(unittest.TestCase):
         self.assertEqual(out.vector.x, -1)
         self.assertEqual(out.vector.y, 0)
         self.assertEqual(out.vector.z, 0)
+
+        v = WrenchStamped()
+        v.wrench.force.x = 1
+        v.wrench.force.y = 0
+        v.wrench.force.z = 0
+        v.wrench.torque.x = 1
+        v.wrench.torque.y = 0
+        v.wrench.torque.z = 0
+
+        out = tf2_geometry_msgs.do_transform_wrench(v, t)
+        self.assertEqual(out.wrench.force.x, -1)
+        self.assertEqual(out.wrench.force.y, 0)
+        self.assertEqual(out.wrench.force.z, 0)
+        self.assertEqual(out.wrench.torque.x, -1)
+        self.assertEqual(out.wrench.torque.y, 0)
+        self.assertEqual(out.wrench.torque.z, 0)
 
 if __name__ == '__main__':
     import rosunit

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -88,9 +88,9 @@ def do_transform_pose(pose, transform):
                                                                           pose.pose.orientation.z, pose.pose.orientation.w),
                                                 PyKDL.Vector(pose.pose.position.x, pose.pose.position.y, pose.pose.position.z))
     res = PoseStamped()
-    res.pose.position.x = f.p[0]
-    res.pose.position.y = f.p[1]
-    res.pose.position.z = f.p[2]
+    res.pose.position.x = f[(0, 3)]
+    res.pose.position.y = f[(1, 3)]
+    res.pose.position.z = f[(2, 3)]
     (res.pose.orientation.x, res.pose.orientation.y, res.pose.orientation.z, res.pose.orientation.w) = f.M.GetQuaternion()
     res.header = transform.header
     return res

--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/tf2_geometry_msgs.py
@@ -27,7 +27,7 @@
 
 # author: Wim Meeussen
 
-from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped
+from geometry_msgs.msg import PoseStamped, Vector3Stamped, PointStamped, WrenchStamped
 import PyKDL
 import rospy
 import tf2_ros
@@ -95,3 +95,16 @@ def do_transform_pose(pose, transform):
     res.header = transform.header
     return res
 tf2_ros.TransformRegistration().add(PoseStamped, do_transform_pose)
+
+# WrenchStamped
+def do_transform_wrench(wrench, transform):
+    force = Vector3Stamped()
+    torque = Vector3Stamped()
+    force.vector = wrench.wrench.force
+    torque.vector = wrench.wrench.torque
+    res = WrenchStamped()
+    res.wrench.force = do_transform_vector3(force, transform).vector
+    res.wrench.torque = do_transform_vector3(torque, transform).vector
+    res.header = transform.header
+    return res
+tf2_ros.TransformRegistration().add(WrenchStamped, do_transform_wrench)

--- a/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
+++ b/tf2_geometry_msgs/test/test_tf2_geometry_msgs.cpp
@@ -325,6 +325,32 @@ TEST(TfGeometry, doTransformVector3)
   EXPECT_NEAR(res.z, 3, EPS);
 }
 
+TEST(TfGeometry, doTransformWrench)
+{
+ geometry_msgs::Wrench v1, res;
+ v1.force.x = 2;
+ v1.force.y = 1;
+ v1.force.z = 3;
+ v1.torque.x = 2;
+ v1.torque.y = 1;
+ v1.torque.z = 3;
+
+ geometry_msgs::TransformStamped trafo;
+ trafo.transform.translation.x = -1;
+ trafo.transform.translation.y = 2;
+ trafo.transform.translation.z = -3;
+ trafo.transform.rotation = tf2::toMsg(tf2::Quaternion(tf2::Vector3(0,0,1), -M_PI / 2.0));
+
+ tf2::doTransform(v1, res, trafo);
+ EXPECT_NEAR(res.force.x, 1, EPS);
+ EXPECT_NEAR(res.force.y, -2, EPS);
+ EXPECT_NEAR(res.force.z, 3, EPS);
+
+ EXPECT_NEAR(res.torque.x, 1, EPS);
+ EXPECT_NEAR(res.torque.y, -2, EPS);
+ EXPECT_NEAR(res.torque.z, 3, EPS);
+}
+
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "test");

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -38,6 +38,7 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/WrenchStamped.h>
 #include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Pose.h>
 
 
 namespace tf2
@@ -248,6 +249,36 @@ inline
 /** \brief Convert a stamped KDL Frame type to a Pose message.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
  * \param in The timestamped KDL Frame to convert.
+ * \return The frame converted to a Pose message.
+ */
+inline
+geometry_msgs::Pose toMsg(const KDL::Frame& in)
+{
+  geometry_msgs::Pose msg;
+  msg.position.x = in.p[0];
+  msg.position.y = in.p[1];
+  msg.position.z = in.p[2];
+  in.M.GetQuaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+  return msg;
+}
+
+/** \brief Convert a Pose message type to a KDL Frame.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * \param msg The Pose message to convert.
+ * \param out The pose converted to a KDL Frame.
+ */
+inline
+void fromMsg(const geometry_msgs::Pose& msg, KDL::Frame& out)
+{
+  out.p[0] = msg.position.x;
+  out.p[1] = msg.position.y;
+  out.p[2] = msg.position.z;
+  out.M = KDL::Rotation::Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+}
+
+/** \brief Convert a stamped KDL Frame type to a Pose message.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param in The timestamped KDL Frame to convert.
  * \return The frame converted to a PoseStamped message.
  */
 inline
@@ -256,15 +287,12 @@ geometry_msgs::PoseStamped toMsg(const tf2::Stamped<KDL::Frame>& in)
   geometry_msgs::PoseStamped msg;
   msg.header.stamp = in.stamp_;
   msg.header.frame_id = in.frame_id_;
-  msg.pose.position.x = in.p[0];
-  msg.pose.position.y = in.p[1];
-  msg.pose.position.z = in.p[2];
-  in.M.GetQuaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+  msg.pose = toMsg(static_cast<const KDL::Frame&>(in));
   return msg;
 }
 
 /** \brief Convert a Pose message transform type to a stamped KDL Frame.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.h.
  * \param msg The PoseStamped message to convert.
  * \param out The pose converted to a timestamped KDL Frame.
  */
@@ -273,12 +301,8 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<KDL::Frame>& ou
 {
   out.stamp_ = msg.header.stamp;
   out.frame_id_ = msg.header.frame_id;
-  out.p[0] = msg.pose.position.x;
-  out.p[1] = msg.pose.position.y;
-  out.p[2] = msg.pose.position.z;
-  out.M = KDL::Rotation::Quaternion(msg.pose.orientation.x, msg.pose.orientation.y, msg.pose.orientation.z, msg.pose.orientation.w);
+  fromMsg(msg.pose, static_cast<KDL::Frame&>(out));
 }
-
 
 } // namespace
 


### PR DESCRIPTION
This is a cherry-pick of the changes in melodic for Kinetic. 

* #307 
* #305 
* #302 
* #301 
* #298 
* #297 
* #294 
* #292 
