### PR TITLE
Add python3.7 compatibility.

### DIFF
--- a/tf2_py/src/python_compat.h
+++ b/tf2_py/src/python_compat.h
@@ -26,10 +26,11 @@ inline PyObject *stringToPython(const char *input)
 inline std::string stringFromPython(PyObject * input)
 {
   Py_ssize_t size;
-  char * data;
 #if PY_MAJOR_VERSION >= 3
+  const char * data;
   data = PyUnicode_AsUTF8AndSize(input, &size);
 #else
+  char * data;
   PyString_AsStringAndSize(input, &data, &size);
 #endif
   return std::string(data, size);


### PR DESCRIPTION
This PR adds compatibility for python3.7. The return type of [PyUnicode_AsUTF8AndSize](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8AndSize) has changed to `const char *` as opposed to `char *`. This change should be compatible with previous versions of python as well.