### PR TITLE
static_transform_publisher: ignore longer than 10 arguments rather than raise error

### DIFF
--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -57,7 +57,7 @@ int main(int argc, char ** argv)
   tf2_ros::StaticTransformBroadcaster broadcaster;
   geometry_msgs::TransformStamped msg;
 
-  if(argc == 10)
+  if(argc >= 10)
   {
     msg.transform.translation.x = atof(argv[1]);
     msg.transform.translation.y = atof(argv[2]);


### PR DESCRIPTION
After this pull request, the `static_transform_publisher` node accepts longer than 10 arguments.
