### PR TITLE
add C++14 standard flag to packages

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(test_tf2)
 
+add_compile_options(-std=c++14)
+
 if(NOT CATKIN_ENABLE_TESTING)
   return()
 endif()

--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2)
 
+add_compile_options(-std=c++14)
+
 find_package(console_bridge REQUIRED)
 find_package(catkin REQUIRED COMPONENTS geometry_msgs rostime tf2_msgs)
 find_package(Boost REQUIRED COMPONENTS signals system thread)

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_bullet)
 
+add_compile_options(-std=c++14)
+
 find_package(PkgConfig REQUIRED)
 
 set(bullet_FOUND 0)

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_eigen)
 
+add_compile_options(-std=c++14)
+
 find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   geometry_msgs

--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_geometry_msgs)
 
+add_compile_options(-std=c++14)
+
 find_package(orocos_kdl)
 find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2_ros tf2)
 find_package(Boost COMPONENTS thread REQUIRED)

--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_kdl)
 
+add_compile_options(-std=c++14)
+
 find_package(orocos_kdl)
 find_package(catkin REQUIRED COMPONENTS cmake_modules tf2 tf2_ros tf2_msgs)
 

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_py)
 
+add_compile_options(-std=c++14)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages

--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_ros)
 
+add_compile_options(-std=c++14)
+
 if(NOT ANDROID)
 set(TF2_PY tf2_py)
 endif()

--- a/tf2_sensor_msgs/CMakeLists.txt
+++ b/tf2_sensor_msgs/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(tf2_sensor_msgs)
 
+add_compile_options(-std=c++14)
+
 find_package(catkin REQUIRED COMPONENTS cmake_modules sensor_msgs tf2_ros tf2)
 find_package(Boost COMPONENTS thread REQUIRED)
 


### PR DESCRIPTION
Have problems with compiling packages with different CMAKE_CXX_STANDARD flags in my project. Fix it by adding C++14 compile option to geometry2 package (as guaranteed in ROS melodic-devel).