### PR TITLE
Fix issue #327

### DIFF
--- a/tf2_ros/CMakeLists.txt
+++ b/tf2_ros/CMakeLists.txt
@@ -114,6 +114,9 @@ add_executable(${PROJECT_NAME}_test_listener EXCLUDE_FROM_ALL test/listener_unit
 add_dependencies(${PROJECT_NAME}_test_listener ${catkin_EXPORTED_TARGETS})
 add_executable(${PROJECT_NAME}_test_time_reset EXCLUDE_FROM_ALL test/time_reset_test.cpp)
 add_dependencies(${PROJECT_NAME}_test_time_reset ${catkin_EXPORTED_TARGETS})
+add_executable(${PROJECT_NAME}_test_message_filter EXCLUDE_FROM_ALL test/message_filter_test.cpp)
+add_dependencies(${PROJECT_NAME}_test_message_filter ${catkin_EXPORTED_TARGETS})
+
 target_link_libraries(${PROJECT_NAME}_test_listener
   ${PROJECT_NAME}
   ${catkin_LIBRARIES}
@@ -126,10 +129,18 @@ target_link_libraries(${PROJECT_NAME}_test_time_reset
   ${GTEST_LIBRARIES}
 )
 
+target_link_libraries(${PROJECT_NAME}_test_message_filter
+  ${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${GTEST_LIBRARIES}
+)
+
 add_dependencies(tests ${PROJECT_NAME}_test_listener)
 add_dependencies(tests ${PROJECT_NAME}_test_time_reset)
+add_dependencies(tests ${PROJECT_NAME}_test_message_filter)
 
 add_rostest(test/transform_listener_unittest.launch)
 add_rostest(test/transform_listener_time_reset_test.launch)
+add_rostest(test/message_filter_test.launch)
 
 endif()

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -244,7 +244,7 @@ public:
 
     target_frames_.resize(target_frames.size());
     std::transform(target_frames.begin(), target_frames.end(), target_frames_.begin(), this->stripSlash);
-    expected_success_count_ = target_frames_.size() + (time_tolerance_.isZero() ? 0 : 1);
+    expected_success_count_ = target_frames_.size() * (time_tolerance_.isZero() ? 1 : 2);
 
     std::stringstream ss;
     for (V_string::iterator it = target_frames_.begin(); it != target_frames_.end(); ++it)
@@ -269,7 +269,7 @@ public:
   {
     boost::mutex::scoped_lock lock(target_frames_mutex_);
     time_tolerance_ = tolerance;
-    expected_success_count_ = target_frames_.size() + (time_tolerance_.isZero() ? 0 : 1);
+    expected_success_count_ = target_frames_.size() * (time_tolerance_.isZero() ? 1 : 2);
   }
 
   /**

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014, Open Source Robotics Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <message_filters/subscriber.h>
+#include <ros/ros.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/message_filter.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <gtest/gtest.h>
+
+
+void spin_for_a_second()
+{
+  ros::spinOnce();
+  for (uint8_t i = 0; i < 10; ++i)
+  {
+    usleep(100);
+    ros::spinOnce();
+  }
+}
+
+bool filter_callback_fired = false;
+void filter_callback(const geometry_msgs::PointStamped& msg)
+{
+  filter_callback_fired = true;
+}
+
+TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
+{
+  ros::NodeHandle nh;
+  message_filters::Subscriber<geometry_msgs::PointStamped> sub;
+  sub.subscribe(nh, "point", 10);
+
+  tf2_ros::Buffer buffer;
+  tf2_ros::TransformListener tfl(buffer);
+  tf2_ros::MessageFilter<geometry_msgs::PointStamped> filter(buffer, "map", 10, nh);
+  filter.connectInput(sub);
+  filter.registerCallback(&filter_callback);
+  // Register multiple target frames
+  std::vector<std::string> frames;
+  frames.push_back("odom");
+  frames.push_back("map");
+  filter.setTargetFrames(frames);
+  // Set a non-zero time tolerance
+  filter.setTolerance(ros::Duration(1, 0));
+
+  // Publish static transforms so the frame transformations will always be valid
+  tf2_ros::StaticTransformBroadcaster tfb;
+  geometry_msgs::TransformStamped map_to_odom;
+  map_to_odom.header.stamp = ros::Time(0, 0);
+  map_to_odom.header.frame_id = "map";
+  map_to_odom.child_frame_id = "odom";
+  map_to_odom.transform.translation.x = 0.0;
+  map_to_odom.transform.translation.y = 0.0;
+  map_to_odom.transform.translation.z = 0.0;
+  map_to_odom.transform.rotation.x = 0.0;
+  map_to_odom.transform.rotation.y = 0.0;
+  map_to_odom.transform.rotation.z = 0.0;
+  map_to_odom.transform.rotation.w = 1.0;
+  tfb.sendTransform(map_to_odom);
+
+  geometry_msgs::TransformStamped odom_to_base;
+  odom_to_base.header.stamp = ros::Time(0, 0);
+  odom_to_base.header.frame_id = "odom";
+  odom_to_base.child_frame_id = "base";
+  odom_to_base.transform.translation.x = 0.0;
+  odom_to_base.transform.translation.y = 0.0;
+  odom_to_base.transform.translation.z = 0.0;
+  odom_to_base.transform.rotation.x = 0.0;
+  odom_to_base.transform.rotation.y = 0.0;
+  odom_to_base.transform.rotation.z = 0.0;
+  odom_to_base.transform.rotation.w = 1.0;
+  tfb.sendTransform(odom_to_base);
+
+  // Publish a Point message in the "base" frame
+  ros::Publisher pub = nh.advertise<geometry_msgs::PointStamped>("point", 10);
+  geometry_msgs::PointStamped point;
+  point.header.stamp = ros::Time::now();
+  point.header.frame_id = "base";
+  pub.publish(point);
+
+  // make sure it arrives
+  spin_for_a_second();
+
+  // The filter callback should have been fired because all required transforms are available
+  ASSERT_TRUE(filter_callback_fired);
+}
+
+int main(int argc, char **argv){
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "tf2_ros_message_filter");
+  return RUN_ALL_TESTS();
+}

--- a/tf2_ros/test/message_filter_test.launch
+++ b/tf2_ros/test/message_filter_test.launch
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="message_filter_test" pkg="tf2_ros" type="tf2_ros_test_message_filter" />
+</launch>
+


### PR DESCRIPTION
Fixes #327 
* Adds a tf2_ros message_filter unittest that uses multiple target frames and a non-zero time tolerance. This unittest fails with the current code version.
* Fixes the internal `expected_success_count_` variable to be the correct value for multiple target frames and a non-zero time tolerance

As described in the issue, there is a bug when both multiple target frames and a non-zero time tolerance are used together.
The transform at the message stamp is checked here:
https://github.com/ros/geometry2/blob/melodic-devel/tf2_ros/include/tf2_ros/message_filter.h#L327
And the transform at the message stamp + tolerance is checked here:
https://github.com/ros/geometry2/blob/melodic-devel/tf2_ros/include/tf2_ros/message_filter.h#L344
Both checks happen for every frame in the `target_frames_` vector. Thus the correct number of transforms to check is `target_frames_.size() * 2` and not `target_frames_.size() + 1` as is currently being done here:
https://github.com/ros/geometry2/blob/melodic-devel/tf2_ros/include/tf2_ros/message_filter.h#L247
https://github.com/ros/geometry2/blob/melodic-devel/tf2_ros/include/tf2_ros/message_filter.h#L272