### PR TITLE
Add check to reset buffer when rostime goes backwards

### DIFF
--- a/tf2_ros/src/tf2_ros/transform_listener.py
+++ b/tf2_ros/src/tf2_ros/transform_listener.py
@@ -50,6 +50,7 @@ class TransformListener():
             :param tcp_nodelay (bool) - if True, request TCP_NODELAY from publisher. Use of this option is not generally recommended in most cases as it is better to rely on timestamps in message data. Setting tcp_nodelay to True enables TCP_NODELAY for all subscribers in the same python process.
         """
         self.buffer = buffer
+        self.last_update = rospy.Time.now()
         self.tf_sub = rospy.Subscriber("/tf", TFMessage, self.callback, queue_size=queue_size, buff_size=buff_size, tcp_nodelay=tcp_nodelay)
         self.tf_static_sub = rospy.Subscriber("/tf_static", TFMessage, self.static_callback, queue_size=queue_size, buff_size=buff_size, tcp_nodelay=tcp_nodelay)
 
@@ -63,12 +64,21 @@ class TransformListener():
         self.tf_sub.unregister()
         self.tf_static_sub.unregister()
 
+    def check_for_reset(self):
+        now = rospy.Time.now()
+        if now < self.last_update:
+            rospy.logwarn("Detected jump back in time of %fs. Clearing TF buffer." % (self.last_update - now).to_sec())
+            self.buffer.clear()
+        self.last_update = now
+
     def callback(self, data):
+        self.check_for_reset()
         who = data._connection_header.get('callerid', "default_authority")
         for transform in data.transforms:
             self.buffer.set_transform(transform, who)
 
     def static_callback(self, data):
+        self.check_for_reset()
         who = data._connection_header.get('callerid', "default_authority")
         for transform in data.transforms:
             self.buffer.set_transform_static(transform, who)


### PR DESCRIPTION
When running a rosbag in a loop and the rosbag is longer than the buffer duration, you will recieve the following warning when it loops:
Warning: TF_OLD_DATA ignoring data from the past for frame {framename} at time 1.53658e+09 according to authority /play_1537197257816658254
Possible reasons are listed at http://wiki.ros.org/tf/Errors%20explained
         at line 277 in /tmp/binarydeb/ros-indigo-tf2-0.5.18/src/buffer_core.cpp
This is caused by the buffer not being reset when the rosbag loops. I have implemented a reset similar to how it is already done in the c++ code, as seen here: https://github.com/ros/geometry2/blob/f0c6ffd465619cfeb0bf89a9fd9d0ab3fb46c80e/tf2_ros/src/transform_listener.cpp#L104-L109
