### PR TITLE
conversions for Eigen::Isometry3d

### DIFF
--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -72,7 +72,7 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Affine3d& T)
   t.transform.translation.y = T.translation().y();
   t.transform.translation.z = T.translation().z();
 
-  Eigen::Quaterniond q(T.rotation());
+  Eigen::Quaterniond q(T.linear());  // assuming that upper 3x3 matrix is orthonormal
   t.transform.rotation.x = q.x();
   t.transform.rotation.y = q.y();
   t.transform.rotation.z = q.z();
@@ -309,10 +309,11 @@ geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
   msg.position.x = in.translation().x();
   msg.position.y = in.translation().y();
   msg.position.z = in.translation().z();
-  msg.orientation.x = Eigen::Quaterniond(in.rotation()).x();
-  msg.orientation.y = Eigen::Quaterniond(in.rotation()).y();
-  msg.orientation.z = Eigen::Quaterniond(in.rotation()).z();
-  msg.orientation.w = Eigen::Quaterniond(in.rotation()).w();
+  Eigen::Quaterniond q(in.linear());
+  msg.orientation.x = q.x();
+  msg.orientation.y = q.y();
+  msg.orientation.z = q.z();
+  msg.orientation.w = q.w();
   return msg;
 }
 

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -215,10 +215,10 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
   fromMsg(msg.point, static_cast<Eigen::Vector3d&>(out));
 }
 
-/** \brief Apply a geometry_msgs Transform to a Eigen-specific affine transform data type.
+/** \brief Apply a geometry_msgs Transform to an Eigen Affine3d transform.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
- * functions rely on the existence of a time stamp and a frame id in the type which should
+ * function relies on the existence of a time stamp and a frame id in the type which should
  * get transformed.
  * \param t_in The frame to transform, as a Eigen Affine3d transform.
  * \param t_out The transformed frame, as a Eigen Affine3d transform.
@@ -438,10 +438,10 @@ void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {
   out[5] = msg.angular.z;
 }
 
-/** \brief Apply a geometry_msgs TransformStamped to a Eigen-specific affine transform data type.
+/** \brief Apply a geometry_msgs TransformStamped to an Eigen Affine3d transform.
  * This function is a specialization of the doTransform template defined in tf2/convert.h,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
- * functions rely on the existence of a time stamp and a frame id in the type which should
+ * function relies on the existence of a time stamp and a frame id in the type which should
  * get transformed.
  * \param t_in The frame to transform, as a timestamped Eigen Affine3d transform.
  * \param t_out The transformed frame, as a timestamped Eigen Affine3d transform.

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -314,6 +314,12 @@ geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
   msg.orientation.y = q.y();
   msg.orientation.z = q.z();
   msg.orientation.w = q.w();
+  if (msg.orientation.w < 0) {
+    msg.orientation.x *= -1;
+    msg.orientation.y *= -1;
+    msg.orientation.z *= -1;
+    msg.orientation.w *= -1;
+  }
   return msg;
 }
 

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -90,14 +90,25 @@ TEST(TfEigen, ConvertQuaterniond)
 
 TEST(TfEigen, TransformQuaterion) {
  const tf2::Stamped<Eigen::Quaterniond> in(Eigen::Quaterniond(Eigen::AngleAxisd(1, Eigen::Vector3d::UnitX())), ros::Time(5), "test");
- const Eigen::Affine3d r(Eigen::AngleAxisd(M_PI/2, Eigen::Vector3d::UnitY()));
+ const Eigen::Isometry3d iso(Eigen::AngleAxisd(M_PI/2, Eigen::Vector3d::UnitY()));
+ const Eigen::Affine3d affine(iso);
  const tf2::Stamped<Eigen::Quaterniond> expected(Eigen::Quaterniond(Eigen::AngleAxisd(1, Eigen::Vector3d::UnitZ())), ros::Time(10), "expected");
 
- geometry_msgs::TransformStamped trafo = tf2::eigenToTransform(r);
+ geometry_msgs::TransformStamped trafo = tf2::eigenToTransform(affine);
  trafo.header.stamp = ros::Time(10);
  trafo.header.frame_id = "expected";
 
  tf2::Stamped<Eigen::Quaterniond> out;
+ tf2::doTransform(in, out, trafo);
+
+ EXPECT_TRUE(out.isApprox(expected));
+ EXPECT_EQ(expected.stamp_, out.stamp_);
+ EXPECT_EQ(expected.frame_id_, out.frame_id_);
+
+ // the same using Isometry
+ trafo = tf2::eigenToTransform(iso);
+ trafo.header.stamp = ros::Time(10);
+ trafo.header.frame_id = "expected";
  tf2::doTransform(in, out, trafo);
 
  EXPECT_TRUE(out.isApprox(expected));
@@ -121,11 +132,40 @@ TEST(TfEigen, ConvertAffine3dStamped)
   EXPECT_EQ(v.stamp_, v1.stamp_);
 }
 
+TEST(TfEigen, ConvertIsometry3dStamped)
+{
+  const Eigen::Isometry3d v_nonstamped(Eigen::Translation3d(1,2,3) * Eigen::AngleAxis<double>(1, Eigen::Vector3d::UnitX()));
+  const tf2::Stamped<Eigen::Isometry3d> v(v_nonstamped, ros::Time(42), "test_frame");
+
+  tf2::Stamped<Eigen::Isometry3d> v1;
+  geometry_msgs::PoseStamped p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
+
+  EXPECT_EQ(v.translation(), v1.translation());
+  EXPECT_EQ(v.rotation(), v1.rotation());
+  EXPECT_EQ(v.frame_id_, v1.frame_id_);
+  EXPECT_EQ(v.stamp_, v1.stamp_);
+}
+
 TEST(TfEigen, ConvertAffine3d)
 {
   const Eigen::Affine3d v(Eigen::Translation3d(1,2,3) * Eigen::AngleAxis<double>(1, Eigen::Vector3d::UnitX()));
 
   Eigen::Affine3d v1;
+  geometry_msgs::Pose p1;
+  tf2::convert(v, p1);
+  tf2::convert(p1, v1);
+
+  EXPECT_EQ(v.translation(), v1.translation());
+  EXPECT_EQ(v.rotation(), v1.rotation());
+}
+
+TEST(TfEigen, ConvertIsometry3d)
+{
+  const Eigen::Isometry3d v(Eigen::Translation3d(1,2,3) * Eigen::AngleAxis<double>(1, Eigen::Vector3d::UnitX()));
+
+  Eigen::Isometry3d v1;
   geometry_msgs::Pose p1;
   tf2::convert(v, p1);
   tf2::convert(p1, v1);
@@ -155,6 +195,14 @@ TEST(TfEigen, ConvertTransform)
   EXPECT_TRUE(T.isApprox(Tback));
   EXPECT_TRUE(tm.isApprox(Tback.matrix()));
 
+  // same for Isometry
+  Eigen::Isometry3d I(tm);
+
+  msg = tf2::eigenToTransform(T);
+  Eigen::Isometry3d Iback = tf2::transformToEigen(msg);
+
+  EXPECT_TRUE(I.isApprox(Iback));
+  EXPECT_TRUE(tm.isApprox(Iback.matrix()));
 }
 
 


### PR DESCRIPTION
In the vein of https://github.com/ros/geometry/pull/113, I added converters for `Eigen::Isometry3d` also to `tf2_eigen`. `Eigen::Affine3d` cannot exploit the SE(3) structure of transforms and thus needs to 
- perform an SVD to compute rotation()
- perform real matrix inversion for inverse()

Hence, `Affine3d` should be actually avoided.