### PR TITLE
Fix python3 import error

### DIFF
--- a/tf2_geometry_msgs/src/tf2_geometry_msgs/__init__.py
+++ b/tf2_geometry_msgs/src/tf2_geometry_msgs/__init__.py
@@ -1,1 +1,1 @@
-from tf2_geometry_msgs import *
+from .tf2_geometry_msgs import *


### PR DESCRIPTION
In python3, relative imports are only allowed using the dot-syntax. The change is compatible to python2, too.