### PR TITLE
tf2_ros: add virtual destructor to tf2_ros::BufferInterface

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -48,6 +48,10 @@ namespace tf2_ros
 class BufferInterface
 {
 public:
+  /** \brief Virtual destructor.
+   * Every class that has virtual methods should have one.
+   */
+  virtual ~BufferInterface() {}
 
   /** \brief Get the transform between two frames by frame ID.
    * \param target_frame The frame to which data should be transformed


### PR DESCRIPTION
Class `tf2_ros::BufferInterface` did not define a virtual destructor, but has virtual methods. This is dangerous because it may lead to memory leaks if instances are deleted using a pointer to the base class (reference: https://stackoverflow.com/questions/1123044/when-should-your-destructor-be-virtual).

Clang and GCC with `-Wnon-virtual-dtor` or `-Weffc++` warn about this:
```
include/tf2_ros/buffer_interface.h:48:7: warning: 'tf2_ros::BufferInterface' has virtual functions but non-virtual destructor [-Wnon-virtual-dtor]                                                             
class BufferInterface                                                                                                                                                                                                                  
      ^                                                     
```