### PR TITLE
Remove legacy inclusion in CMakeLists of tf2.

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -7,11 +7,10 @@ find_package(Boost REQUIRED COMPONENTS signals system thread)
 
 catkin_package(
    INCLUDE_DIRS include
-   LIBRARIES tf2 
+   LIBRARIES tf2
    DEPENDS console_bridge
    CATKIN_DEPENDS geometry_msgs tf2_msgs rostime)
 
-include_directories (src/bt)
 include_directories(include ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 
 # export user definitions


### PR DESCRIPTION
Fixes #351 

directory `src/bt` does not exist anymore.
(Also extra space after `tf2` is removed.)