### PR TITLE
Remove `signals` from find_package(Boost COMPONENTS ...).

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -3,7 +3,7 @@ project(tf2)
 
 find_package(console_bridge REQUIRED)
 find_package(catkin REQUIRED COMPONENTS geometry_msgs rostime tf2_msgs)
-find_package(Boost REQUIRED COMPONENTS signals system thread)
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 catkin_package(
    INCLUDE_DIRS include


### PR DESCRIPTION
tf2 is using signals2, which is not the same library. Additionally, signals2 has always been header only, and header only libraries must not be listed in `find_package(Boost COMPONENTS ...)`.

Boost 1.69 removed the old signals library entirely, so the otherwise harmless `COMPONENTS signals` actually breaks the build now.