### PR TITLE
Follow #337: use actionlib API in BufferClient::processGoal()

### DIFF
--- a/tf2_ros/include/tf2_ros/buffer_client.h
+++ b/tf2_ros/include/tf2_ros/buffer_client.h
@@ -56,7 +56,7 @@ namespace tf2_ros
 
       /** \brief BufferClient constructor
        * \param ns The namespace in which to look for a BufferServer
-       * \param check_frequency The frequency in Hz to check whether the BufferServer has completed a request
+       * \param check_frequency Deprecated, not used anymore
        * \param timeout_padding The amount of time to allow passed the desired timeout on the client side for communication lag
        */
       BufferClient(std::string ns, double check_frequency = 10.0, ros::Duration timeout_padding = ros::Duration(2.0));

--- a/tf2_ros/src/buffer_client.cpp
+++ b/tf2_ros/src/buffer_client.cpp
@@ -79,17 +79,9 @@ namespace tf2_ros
   geometry_msgs::TransformStamped BufferClient::processGoal(const tf2_msgs::LookupTransformGoal& goal) const
   {
     client_.sendGoal(goal);
-    ros::Rate r(check_frequency_);
-    bool timed_out = false;
-    ros::Time start_time = ros::Time::now();
-    while(ros::ok() && !client_.getState().isDone() && !timed_out)
-    {
-      timed_out = ros::Time::now() > start_time + goal.timeout + timeout_padding_;
-      r.sleep();
-    }
 
     //this shouldn't happen, but could in rare cases where the server hangs
-    if(timed_out)
+    if(!client_.waitForResult(goal.timeout + timeout_padding_))
     {
       //make sure to cancel the goal the server is pursuing
       client_.cancelGoal();


### PR DESCRIPTION
Follows the changes to the Python API from #337 to simplify the action client logic.
