### PR TITLE
use ROS_DEPRECATED macro for portability

### DIFF
--- a/tf2/include/tf2/LinearMath/Matrix3x3.h
+++ b/tf2/include/tf2/LinearMath/Matrix3x3.h
@@ -19,6 +19,8 @@ subject to the following restrictions:
 #include "Vector3.h"
 #include "Quaternion.h"
 
+#include <ros/macros.h>
+
 namespace tf2
 {
 
@@ -163,7 +165,7 @@ public:
 	*  @param pitch Pitch about Y axis
 	*  @param roll Roll about X axis 
 	*/
-	void setEulerZYX(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll) __attribute__((deprecated))
+	ROS_DEPRECATED void setEulerZYX(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll)
 	{
 		setEulerYPR(yaw, pitch, roll);
 	}
@@ -279,7 +281,7 @@ public:
 	* @param pitch Pitch around Y axis
 	* @param roll around X axis 
  	* @param solution_number Which solution of two possible solutions ( 1 or 2) are possible values*/	
-	__attribute__((deprecated)) void getEulerZYX(tf2Scalar& yaw, tf2Scalar& pitch, tf2Scalar& roll, unsigned int solution_number = 1) const
+	ROS_DEPRECATED void getEulerZYX(tf2Scalar& yaw, tf2Scalar& pitch, tf2Scalar& roll, unsigned int solution_number = 1) const
 	{
 		getEulerYPR(yaw, pitch, roll, solution_number);
 	};

--- a/tf2/include/tf2/LinearMath/Quaternion.h
+++ b/tf2/include/tf2/LinearMath/Quaternion.h
@@ -21,6 +21,8 @@ subject to the following restrictions:
 #include "Vector3.h"
 #include "QuadWord.h"
 
+#include <ros/macros.h>
+
 namespace tf2
 {
 
@@ -47,7 +49,7 @@ public:
    * @param yaw Angle around Y unless TF2_EULER_DEFAULT_ZYX defined then Z
    * @param pitch Angle around X unless TF2_EULER_DEFAULT_ZYX defined then Y
    * @param roll Angle around Z unless TF2_EULER_DEFAULT_ZYX defined then X */
-  Quaternion(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll) __attribute__((deprecated))
+  ROS_DEPRECATED Quaternion(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll)
 	{ 
 #ifndef TF2_EULER_DEFAULT_ZYX
 		setEuler(yaw, pitch, roll); 
@@ -110,7 +112,7 @@ public:
    * @param yaw Angle around Z
    * @param pitch Angle around Y
    * @param roll Angle around X */
-  void setEulerZYX(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll) __attribute__((deprecated))
+  ROS_DEPRECATED void setEulerZYX(const tf2Scalar& yaw, const tf2Scalar& pitch, const tf2Scalar& roll)
 	{
           setRPY(roll, pitch, yaw);
 	}

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -46,6 +46,8 @@
 #include <geometry_msgs/WrenchStamped.h>
 #include <kdl/frames.hpp>
 
+#include "ros/macros.h"
+
 namespace tf2
 {
 
@@ -55,7 +57,7 @@ namespace tf2
  * \deprecated
  */
 inline
-KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t) __attribute__ ((deprecated));
+KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t) ROS_DEPRECATED;
 inline
 KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
   {
@@ -379,7 +381,7 @@ geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
 
 template <>
 inline
-geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)  __attribute__ ((deprecated));
+geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in) ROS_DEPRECATED;
 
 
 //Backwards compatibility remove when forked for Lunar or newer
@@ -407,7 +409,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quate
 
 template<>
 inline
-void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out) __attribute__ ((deprecated));
+void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out) ROS_DEPRECATED;
 
 //Backwards compatibility remove when forked for Lunar or newer
 template<>

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -57,7 +57,7 @@ namespace tf2
  * \deprecated
  */
 inline
-KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t) ROS_DEPRECATED;
+ROS_DEPRECATED KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t);
 inline
 KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
   {
@@ -381,7 +381,7 @@ geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
 
 template <>
 inline
-geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in) ROS_DEPRECATED;
+ROS_DEPRECATED geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in);
 
 
 //Backwards compatibility remove when forked for Lunar or newer
@@ -409,7 +409,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quate
 
 template<>
 inline
-void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out) ROS_DEPRECATED;
+ROS_DEPRECATED void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out);
 
 //Backwards compatibility remove when forked for Lunar or newer
 template<>


### PR DESCRIPTION
`__attribute__((deprecated))` does not work for MSVC, use `ROS_DEPRECATED` to mask all compiler-specific macros