### PR TITLE
use .pyd instead of .so on Windows and export symbols

### DIFF
--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -94,12 +94,12 @@ add_library(tf2_py src/tf2_py.cpp)
 target_link_libraries(tf2_py ${catkin_LIBRARIES})
 add_dependencies(tf2_py ${catkin_EXPORTED_TARGETS})
 
-# The .so extension is meaningless on Windows
-if (NOT MSVC)
+if(WIN32)
+  # use .pyd extension on Windows
+  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".pyd")
+else()
   set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
-else()
-  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".pyd")
 endif()
 set_target_properties(tf2_py PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
@@ -144,12 +144,12 @@ set_target_properties(tf2_py PROPERTIES
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
 
-if (NOT MSVC)
-  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.so
+if(WIN32)
+  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.pyd
     DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
   )
 else()
-  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.pyd
+  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.so
     DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
   )
 endif()

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -99,7 +99,7 @@ if (NOT MSVC)
   set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
 else()
-  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".dll")
+  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".pyd")
 endif()
 set_target_properties(tf2_py PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
@@ -149,7 +149,7 @@ if (NOT MSVC)
     DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
   )
 else()
-  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.dll
+  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.pyd
     DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
   )
 endif()

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -94,11 +94,17 @@ add_library(tf2_py src/tf2_py.cpp)
 target_link_libraries(tf2_py ${catkin_LIBRARIES})
 add_dependencies(tf2_py ${catkin_EXPORTED_TARGETS})
 
-set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
-set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
+# The .so extension is meaningless on Windows
+if (NOT MSVC)
+  set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
+  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
+else()
+  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".dll")
+endif()
 set_target_properties(tf2_py PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
   LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
+  RUNTIME_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}
 )
 #!! rosbuild_add_compile_flags(tf2_py ${SSE_FLAGS}) #conditionally adds sse flags if available
 
@@ -138,10 +144,15 @@ set_target_properties(tf2_py PROPERTIES
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
 
-install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.so
-  DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
-)
-
+if (NOT MSVC)
+  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.so
+    DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
+  )
+else()
+  install(FILES ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}/_tf2.dll
+    DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION}
+  )
+endif()
 
 #############
 ## Testing ##

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -616,11 +616,14 @@ PyObject *moduleInit(PyObject *m) {
 }
 
 #if PY_MAJOR_VERSION < 3
-extern "C" void init_tf2()
+extern "C"
 {
-  if (!staticInit())
-    return;
-  moduleInit(Py_InitModule("_tf2", module_methods));
+  ROS_HELPER_EXPORT void init_tf2()
+  {
+    if (!staticInit())
+      return;
+    moduleInit(Py_InitModule("_tf2", module_methods));
+  }
 }
 
 #else


### PR DESCRIPTION
- use `.pyd` extension instead of the Linux-specific `.so` extension
- `.pyd` is just like `.dll` (shared library), needs to add `RUNTIME_OUTPUT_DIRECTORY` so it gets exported
- `init_tf2()` in `tf2_py.cpp` needs to be exported in the shared library so it could consumed by other modules