### PR TITLE
use find_package when pkg_check_modules doesn't work

### DIFF
--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -3,11 +3,12 @@ project(tf2_bullet)
 
 find_package(PkgConfig REQUIRED)
 
-if(MSVC)
-find_package(bullet REQUIRED)
-else()
 set(bullet_FOUND 0)
-pkg_check_modules(bullet REQUIRED bullet)
+pkg_check_modules(bullet bullet)
+if(NOT bullet_FOUND)
+    # windows build bullet3 doesn't come with pkg-config by default and it only comes with CMake config files
+    # so pkg_check_modules will fail
+    find_package(bullet REQUIRED)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2)

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -3,8 +3,12 @@ project(tf2_bullet)
 
 find_package(PkgConfig REQUIRED)
 
+if(MSVC)
+find_package(bullet REQUIRED)
+else()
 set(bullet_FOUND 0)
 pkg_check_modules(bullet REQUIRED bullet)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2)
 


### PR DESCRIPTION
use `find_package` when `pkg_check_modules` doesn't work, for example, on Windows the `bullet3` package doesn't come with pkg-config by default, so it needs to use `pkg_check_modules`