### PR TITLE
avoid name collision with windows.h

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -32,6 +32,12 @@
 #include "tf2/buffer_core.h"
 #include "tf2/time_cache.h"
 #include "tf2/exceptions.h"
+
+// Boost winapi.h includes winerror.h, which defines NO_ERROR.
+// this would conflict with tf2_msgs::TF2Error::NO_ERROR.
+#if defined(_WIN32) && defined(NO_ERROR)
+    #undef NO_ERROR
+#endif
 #include "tf2_msgs/TF2Error.h"
 
 #include <assert.h>

--- a/tf2_ros/include/tf2_ros/buffer_client.h
+++ b/tf2_ros/include/tf2_ros/buffer_client.h
@@ -39,6 +39,12 @@
 
 #include <tf2_ros/buffer_interface.h>
 #include <actionlib/client/simple_action_client.h>
+
+// Boost winapi.h includes winerror.h, which defines NO_ERROR.
+// this would conflict with tf2_msgs::TF2Error::NO_ERROR.
+#if defined(_WIN32) && defined(NO_ERROR)
+    #undef NO_ERROR
+#endif
 #include <tf2_msgs/LookupTransformAction.h>
 
 namespace tf2_ros

--- a/tf2_ros/include/tf2_ros/buffer_server.h
+++ b/tf2_ros/include/tf2_ros/buffer_server.h
@@ -38,6 +38,12 @@
 #define TF2_ROS_BUFFER_SERVER_H_
 
 #include <actionlib/server/action_server.h>
+
+// Boost winapi.h includes winerror.h, which defines NO_ERROR.
+// this would conflict with tf2_msgs::TF2Error::NO_ERROR.
+#if defined(_WIN32) && defined(NO_ERROR)
+    #undef NO_ERROR
+#endif
 #include <tf2_msgs/LookupTransformAction.h>
 #include <geometry_msgs/TransformStamped.h>
 #include <tf2_ros/buffer.h>


### PR DESCRIPTION
`winerror.h` is implicitly included in source code and `NO_ERROR` is defined as a macro inside it. In order to use `tf2_msgs::TF2Error::NO_ERROR` correctly, `NO_ERROR` from `winerror.h` needs to be un-defined to avoid name collision