### PR TITLE
add missing <array>

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -46,6 +46,8 @@
 #include <geometry_msgs/WrenchStamped.h>
 #include <kdl/frames.hpp>
 
+#include <array>
+
 #include "ros/macros.h"
 
 namespace tf2


### PR DESCRIPTION
`std::array` has [explicit usage](https://github.com/ros/geometry2/blob/melodic-devel/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h#L1022) in `tf2_geometry_msgs`, needs to add `<array>` to fix build issue in downstream projects