### PR TITLE
rework Eigen functions namespace hack

### DIFF
--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -32,75 +32,10 @@
 #ifndef TF2_CONVERT_H
 #define TF2_CONVERT_H
 
-
-#include <tf2/transform_datatypes.h>
-#include <tf2/exceptions.h>
-#include <geometry_msgs/TransformStamped.h>
+#include <tf2/transform_functions.h>
 #include <tf2/impl/convert.h>
 
 namespace tf2 {
-
-/**\brief The templated function expected to be able to do a transform
- *
- * This is the method which tf2 will use to try to apply a transform for any given datatype.   
- * \param data_in The data to be transformed.
- * \param data_out A reference to the output data.  Note this can point to data in and the method should be mutation safe.
- * \param transform The transform to apply to data_in to fill data_out.  
- * 
- * This method needs to be implemented by client library developers
- */
-template <class T>
-  void doTransform(const T& data_in, T& data_out, const geometry_msgs::TransformStamped& transform);
-
-/**\brief Get the timestamp from data 
- * \param t The data input.
- * \return The timestamp associated with the data. The lifetime of the returned
- * reference is bound to the lifetime of the argument.
- */
-template <class T>
-  const ros::Time& getTimestamp(const T& t);
-
-/**\brief Get the frame_id from data 
- * \param t The data input.
- * \return The frame_id associated with the data. The lifetime of the returned
- * reference is bound to the lifetime of the argument.
- */
-template <class T>
-  const std::string& getFrameId(const T& t);
-
-
-
-/* An implementation for Stamped<P> datatypes */
-template <class P>
-  const ros::Time& getTimestamp(const tf2::Stamped<P>& t)
-  {
-    return t.stamp_;
-  }
-
-/* An implementation for Stamped<P> datatypes */
-template <class P>
-  const std::string& getFrameId(const tf2::Stamped<P>& t)
-  {
-    return t.frame_id_;
-  }
-
-/** Function that converts from one type to a ROS message type. It has to be
- * implemented by each data type in tf2_* (except ROS messages) as it is
- * used in the "convert" function.
- * \param a an object of whatever type
- * \return the conversion as a ROS message
- */
-template<typename A, typename B>
-  B toMsg(const A& a);
-
-/** Function that converts from a ROS message type to another type. It has to be
- * implemented by each data type in tf2_* (except ROS messages) as it is used
- * in the "convert" function.
- * \param a a ROS message to convert from
- * \param b the object to convert to
- */
-template<typename A, typename B>
-  void fromMsg(const A&, B& b);
 
 /** Function that converts any type to any type (messages or not).
  * Matching toMsg and from Msg conversion functions need to exist.
@@ -123,7 +58,6 @@ template <class A>
     if(&a1 != &a2)
       a2 = a1;
   }
-
 
 }
 

--- a/tf2/include/tf2/transform_functions.h
+++ b/tf2/include/tf2/transform_functions.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2013, Open Source Robotics Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Tully Foote */
+
+#ifndef TF2_TRANSFORM_FUNCTIONS_H
+#define TF2_TRANSFORM_FUNCTIONS_H
+
+#include <tf2/transform_datatypes.h>
+#include <tf2/exceptions.h>
+#include <geometry_msgs/TransformStamped.h>
+
+namespace tf2 {
+
+/**\brief The templated function expected to be able to do a transform
+ *
+ * This is the method which tf2 will use to try to apply a transform for any given datatype.   
+ * \param data_in The data to be transformed.
+ * \param data_out A reference to the output data.  Note this can point to data in and the method should be mutation safe.
+ * \param transform The transform to apply to data_in to fill data_out.  
+ * 
+ * This method needs to be implemented by client library developers
+ */
+template <class T>
+  void doTransform(const T& data_in, T& data_out, const geometry_msgs::TransformStamped& transform);
+
+/**\brief Get the timestamp from data 
+ * \param t The data input.
+ * \return The timestamp associated with the data. The lifetime of the returned
+ * reference is bound to the lifetime of the argument.
+ */
+template <class T>
+  const ros::Time& getTimestamp(const T& t);
+
+/**\brief Get the frame_id from data 
+ * \param t The data input.
+ * \return The frame_id associated with the data. The lifetime of the returned
+ * reference is bound to the lifetime of the argument.
+ */
+template <class T>
+  const std::string& getFrameId(const T& t);
+
+/* An implementation for Stamped<P> datatypes */
+template <class P>
+  const ros::Time& getTimestamp(const tf2::Stamped<P>& t)
+  {
+    return t.stamp_;
+  }
+
+/* An implementation for Stamped<P> datatypes */
+template <class P>
+  const std::string& getFrameId(const tf2::Stamped<P>& t)
+  {
+    return t.frame_id_;
+  }
+
+/** Function that converts from one type to a ROS message type. It has to be
+ * implemented by each data type in tf2_* (except ROS messages) as it is
+ * used in the "convert" function.
+ * \param a an object of whatever type
+ * \return the conversion as a ROS message
+ */
+template<typename A, typename B>
+  B toMsg(const A& a);
+
+/** Function that converts from a ROS message type to another type. It has to be
+ * implemented by each data type in tf2_* (except ROS messages) as it is used
+ * in the "convert" function.
+ * \param a a ROS message to convert from
+ * \param b the object to convert to
+ */
+template<typename A, typename B>
+  void fromMsg(const A&, B& b);
+
+}
+
+#endif //TF2_TRANSFORM_FUNCTIONS_H

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -29,7 +29,7 @@
 #ifndef TF2_EIGEN_H
 #define TF2_EIGEN_H
 
-#include <tf2/convert.h>
+#include <tf2/transform_functions.h>
 #include <Eigen/Geometry>
 #include <geometry_msgs/QuaternionStamped.h>
 #include <geometry_msgs/PointStamped.h>
@@ -520,66 +520,7 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<Eigen::Isometry
 
 } // namespace
 
-
-namespace Eigen {
-// This is needed to make the usage of the following conversion functions usable in tf2::convert().
-// According to clangs error note 'fromMsg'/'toMsg' should be declared prior to the call site or
-// in an associated namespace of one of its arguments. The stamped versions of this conversion
-// functions work because they have tf2::Stamped as an argument which is the same namespace as
-// which 'fromMsg'/'toMsg' is defined in. The non-stamped versions have no argument which is
-// defined in tf2, so it take the following definitions in Eigen namespace to make them usable in
-// tf2::convert().
-
-inline
-geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
-  return tf2::toMsg(in);
-}
-
-inline
-geometry_msgs::Pose toMsg(const Eigen::Isometry3d& in) {
-  return tf2::toMsg(in);
-}
-
-inline
-void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out) {
-  tf2::fromMsg(msg, out);
-}
-
-inline
-geometry_msgs::Point toMsg(const Eigen::Vector3d& in) {
-  return tf2::toMsg(in);
-}
-
-inline
-void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
-  tf2::fromMsg(msg, out);
-}
-
-inline
-void fromMsg(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out) {
-  tf2::fromMsg(msg, out);
-}
-
-inline
-geometry_msgs::Quaternion toMsg(const Eigen::Quaterniond& in) {
-  return tf2::toMsg(in);
-}
-
-inline
-void fromMsg(const geometry_msgs::Quaternion& msg, Eigen::Quaterniond& out) {
-  tf2::fromMsg(msg, out);
-}
-
-inline
-geometry_msgs::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
-  return tf2::toMsg(in);
-}
-
-inline
-void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {
-  tf2::fromMsg(msg, out);
-}
-
-} // namespace
+// tf2/convert.h needs to be included after all toMsg/fromMsg are defined
+#include <tf2/convert.h>
 
 #endif // TF2_EIGEN_H


### PR DESCRIPTION
without specifying the `tf2` namespace, it would lead to build issue with MSVC, log from our [daily build](https://ros-win.visualstudio.com/ros-win/_build/results?buildId=3225):
```
wrap_python_move_group.cpp
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\py_bindings_tools\include\moveit/py_bindings_tools/serialize_msg.h(69): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\move_group_interface\src\wrap_python_move_group.cpp(97): note: see reference to function template instantiation 'void moveit::py_bindings_tools::deserializeMsg<geometry_msgs::Pose>(const std::string &,T &)' being compiled
with
[
T=geometry_msgs::Pose
]
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(54): note: see reference to class template instantiation 'boost::arg<9>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(53): note: see reference to class template instantiation 'boost::arg<8>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(52): note: see reference to class template instantiation 'boost::arg<7>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(51): note: see reference to class template instantiation 'boost::arg<6>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(50): note: see reference to class template instantiation 'boost::arg<5>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(49): note: see reference to class template instantiation 'boost::arg<4>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(48): note: see reference to class template instantiation 'boost::arg<3>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(47): note: see reference to class template instantiation 'boost::arg<2>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(46): note: see reference to class template instantiation 'boost::arg<1>' being compiled
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\py_bindings_tools\include\moveit/py_bindings_tools/serialize_msg.h(58): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\move_group_interface\src\wrap_python_move_group.cpp(138): note: see reference to function template instantiation 'std::string moveit::py_bindings_tools::serializeMsg<moveit_msgs::RobotState>(const T &)' being compiled
with
[
T=moveit_msgs::RobotState
]
C:\opt\ros\melodic\x64\include\tf2/impl/convert.h(72): error C2668: 'tf2::fromMsg': ambiguous call to overloaded function
```

since function definitions in `impl/convert.h` are using [functions](https://github.com/ros/geometry2/blob/melodic-devel/tf2/include/tf2/convert.h#L93) in the `tf2` namespace from `convert.h`, it still makes sense to add the `tf2` scope to make sure the correct function signature is picked