### PR TITLE
add mode to subscribe only static_tf to tf2_ros

### DIFF
--- a/tf2_ros/include/tf2_ros/transform_listener.h
+++ b/tf2_ros/include/tf2_ros/transform_listener.h
@@ -50,16 +50,16 @@ class TransformListener
 
 public:
   /**@brief Constructor for transform listener */
-  TransformListener(tf2::BufferCore& buffer, bool spin_thread = true);
-  TransformListener(tf2::BufferCore& buffer, const ros::NodeHandle& nh, bool spin_thread = true);
+  TransformListener(tf2::BufferCore& buffer, bool spin_thread = true, bool only_static = false);
+  TransformListener(tf2::BufferCore& buffer, const ros::NodeHandle& nh, bool spin_thread = true, bool only_static = false);
 
   ~TransformListener();
 
 private:
 
   /// Initialize this transform listener, subscribing, advertising services, etc.
-  void init();
-  void initWithThread();
+  void init(bool only_static);
+  void initWithThread(bool only_static);
 
   /// Callback function for ros message subscriptoin
   void subscription_callback(const ros::MessageEvent<tf2_msgs::TFMessage const>& msg_evt);


### PR DESCRIPTION
Even if we want to use only static_tf, tf is also forced to subscribe, so the computational cost becomes an issue. Added mode to subscribe only static_tf.