### PR TITLE
Allow to choose output precision in echo

### DIFF
--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -36,7 +36,7 @@ import argparse
 import math
 import numpy
 import rospy
-# import sys
+import sys
 import tf2_py as tf2
 import tf2_ros
 
@@ -212,6 +212,15 @@ def positive_int(x):
 
 if __name__ == '__main__':
     rospy.init_node("echo")
+
+    other_args = rospy.myargv(argv=sys.argv)
+    precision=3
+    try:
+        precision = rospy.get_param('~precision')
+        rospy.loginfo("Precision default value was overriden, new value: %d", precision)
+    except KeyError:
+        pass
+
     parser = argparse.ArgumentParser()
     parser.add_argument("source_frame")  # parent
     parser.add_argument("target_frame")  # child
@@ -233,9 +242,8 @@ if __name__ == '__main__':
                         type=positive_int)
     parser.add_argument("-p", "--precision",
                         help="output precision",
-                        default=3,
+                        default=precision,
                         type=positive_int)
-    args = parser.parse_args()
-
+    args = parser.parse_args(other_args[1:]) # Remove first arg
     echo = Echo(args)
     rospy.spin()

--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -184,18 +184,18 @@ class Echo():
         # will be identical.
         msg = "At time {}, (current time {})".format(ts.header.stamp.to_sec(), cur_time.to_sec())
         xyz = ts.transform.translation
-        msg += "\n- Translation: [{:.3f}, {:.3f}, {:.3f}]\n".format(xyz.x, xyz.y, xyz.z)
+        msg += "\n- Translation: [{:.{p}f}, {:.{p}f}, {:.{p}f}]\n".format(xyz.x, xyz.y, xyz.z, p=self.args.precision)
         quat = ts.transform.rotation
-        msg += "- Rotation: in Quaternion [{:.3f}, {:.3f}, {:.3f}, {:.3f}]\n".format(quat.x, quat.y, quat.z, quat.w)
+        msg += "- Rotation: in Quaternion [{:.{p}f}, {:.{p}f}, {:.{p}f}, {:.{p}f}]\n".format(quat.x, quat.y, quat.z, quat.w, p=self.args.precision)
         # TODO(lucasw) need to get quaternion to euler from somewhere, but not tf1
         # or a dependency that isn't in Ubuntu or ros repos
         euler = _euler_from_quaternion_msg(quat)
         msg += "            in RPY (radian) "
-        msg += "[{:.3f}, {:.3f}, {:.3f}]\n".format(euler[0], euler[1], euler[2])
+        msg += "[{:.{p}f}, {:.{p}f}, {:.{p}f}]\n".format(euler[0], euler[1], euler[2], p=self.args.precision)
         msg += "            in RPY (degree) "
-        msg += "[{:.3f}, {:.3f}, {:.3f}]".format(math.degrees(euler[0]),
+        msg += "[{:.{p}f}, {:.{p}f}, {:.{p}f}]".format(math.degrees(euler[0]),
                                                  math.degrees(euler[1]),
-                                                 math.degrees(euler[2]))
+                                                 math.degrees(euler[2]), p=self.args.precision)
         print(msg)
 
 def positive_float(x):
@@ -230,6 +230,10 @@ if __name__ == '__main__':
                         type=float)
     parser.add_argument("-l", "--limit",
                         help="lookup fixed number of times",
+                        type=positive_int)
+    parser.add_argument("-p", "--precision",
+                        help="output precision",
+                        default=3,
                         type=positive_int)
     args = parser.parse_args()
 


### PR DESCRIPTION
Similar to https://github.com/ros/geometry/pull/186

With this PR it is possible to choose the precision of the pose output by passing an argument to the node:
```bash
rosrun tf2_tools echo.py base tool0 -p 8
```

I am inspecting robot poses and I need at least millimeter precision. This allows getting the precision without cluttering the default output.

Example run:
```bash
rosrun tf2_tools echo.py base tool0 -p 8
At time 1556183292.91, (current time 1556183292.96)
- Translation: [1.34024981, 0.00000000, 1.04058951]
- Rotation: in Quaternion [0.70693168, 0.00000000, 0.70728184, -0.00000000]
            in RPY (radian) [0.00000000, -1.57030113, 3.14159265]
            in RPY (degree) [0.00000000, -89.97162713, 180.00000000]

```