### PR TITLE
Fixed crash when callback is called after MessageFilter was destroyed

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -214,6 +214,10 @@ public:
    */
   ~MessageFilter()
   {
+    if (callback_queue_)
+    {
+      callback_queue_->removeByID((uint64_t)this);
+    }
     message_connection_.disconnect();
 
     clear();


### PR DESCRIPTION
see #379

There's one assumption that I'm making which is that the removeByID method is a silently failing no-op if there is no callback registered for the given id.
Since it is an interface and I don't know where the actual implementation is located, I couldn't check that.