### PR TITLE
Fixed race condition in MessageFilter by removing the callback

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -214,6 +214,10 @@ public:
    */
   ~MessageFilter()
   {
+    if (callback_queue_)
+    {
+      callback_queue_->removeByID((uint64_t)this);
+    }
     message_connection_.disconnect();
 
     clear();


### PR DESCRIPTION
This pull request fixes issue #379 by simply removing the callbacks in the destructor.

It is an alternative to #383.
Cons:
  * Might not always fix the issue in multithreaded environments depending on the implementation/thread-safety of the CallbackQueue

Pros:
  * simple and no overhead