### PR TITLE
Fix compile error missing ros/ros.h

### DIFF
--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -30,7 +30,7 @@
 #include <gtest/gtest.h>
 #include <tf2/buffer_core.h>
 #include <sys/time.h>
-#include <ros/ros.h>
+#include <ros/time.h>
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"
 

--- a/tf2_bullet/test/test_tf2_bullet.cpp
+++ b/tf2_bullet/test/test_tf2_bullet.cpp
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2008, Willow Garage, Inc.
- * All rights reserved.
+ * Copyright (c) 2008, Willow Garage, Inc.  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,7 +30,6 @@
 
 
 #include <tf2_bullet/tf2_bullet.h>
-#include <ros/ros.h>
 #include <gtest/gtest.h>
 #include <tf2/convert.h>
 

--- a/tf2_bullet/test/test_tf2_bullet.cpp
+++ b/tf2_bullet/test/test_tf2_bullet.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2008, Willow Garage, Inc.  * All rights reserved.
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -28,7 +28,6 @@
 
 
 #include <tf2_eigen/tf2_eigen.h>
-#include <ros/ros.h>
 #include <gtest/gtest.h>
 #include <tf2/convert.h>
 


### PR DESCRIPTION
I'm unable to build `tf2`, `tf2_bullet`, or `tf2_eigen` using `catkin_make_isolated` without this patch. The `tf2` package depends on `rostime`, so it can't include `ros/ros.h`. Doing so results in a compile failure

```
/tmp/melodic-py3/src/geometry2/tf2/test/simple_tf2_core.cpp:33:10: fatal error: ros/ros.h: No such file or directory
 #include <ros/ros.h>
          ^~~~~~~~~~~
compilation terminated.
```

This changes the include to `<ros/time.h>` from the `rostime` package, which `tf2` does depend on.

The `tf2_bullet` package doesn't need the `ros/ros.h` header at all so this removes it.

```
/tmp/melodic-py3/src/geometry2/tf2_bullet/test/test_tf2_bullet.cpp:34:10: fatal error: ros/ros.h: No such file or directory
 #include <ros/ros.h>
          ^~~~~~~~~~~
compilation terminated.
```

The `tf2_eigen` package doesn't need the header either.

```
/tmp/melodic-py3/src/geometry2/tf2_eigen/test/tf2_eigen-test.cpp:31:10: fatal error: ros/ros.h: No such file or directory
 #include <ros/ros.h>
          ^~~~~~~~~~~
compilation terminated.
```