### PR TITLE
Fix message filter

### DIFF
--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -216,7 +216,7 @@ public:
   {
     message_connection_.disconnect();
 
-    clear();
+    MessageFilter::clear();
 
     TF2_ROS_MESSAGEFILTER_DEBUG("Successful Transforms: %llu, Discarded due to age: %llu, Transform messages received: %llu, Messages received: %llu, Total dropped: %llu",
                            (long long unsigned int)successful_transform_count_,

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -287,6 +287,10 @@ public:
     messages_.clear();
     message_count_ = 0;
 
+    // remove pending callbacks in callback queue as well
+    if (callback_queue_)
+      callback_queue_->removeByID((uint64_t)this);
+
     warned_about_empty_frame_id_ = false;
   }
 


### PR DESCRIPTION
This fixes a segfault of `MessageFilter` pointed out in https://github.com/ros-visualization/rviz/issues/1372 and analyzed in detail in https://github.com/ros-visualization/rviz/pull/1393.
Essentially, when destroying/clearing the filter, all pending callbacks (which store a pointer to the filter itself) should be removed. Otherwise, when called, these callbacks will access the destroyed filter pointer.
Additionally, in a destructor, only fully-qualified virtual functions may be called.