### PR TITLE
Remove roslib.load_manifest

### DIFF
--- a/test_tf2/test/test_buffer_client.py
+++ b/test_tf2/test/test_buffer_client.py
@@ -35,7 +35,6 @@
 #* Author: Eitan Marder-Eppstein
 #***********************************************************
 PKG = 'test_tf2'
-import roslib; roslib.load_manifest(PKG)
 
 import sys
 import unittest

--- a/test_tf2/test/test_convert.py
+++ b/test_tf2/test/test_convert.py
@@ -38,7 +38,6 @@
 from __future__ import print_function
 
 PKG = 'test_tf2'
-import roslib; roslib.load_manifest(PKG)
 
 import sys
 import unittest

--- a/test_tf2/test/test_static_publisher.py
+++ b/test_tf2/test/test_static_publisher.py
@@ -40,7 +40,6 @@ import unittest
 
 import rospy
 PKG = 'test_tf2'
-import roslib; roslib.load_manifest(PKG)
 
 
 class TestStaticPublisher(unittest.TestCase):

--- a/tf2_kdl/src/tf2_kdl/tf2_kdl.py
+++ b/tf2_kdl/src/tf2_kdl/tf2_kdl.py
@@ -27,7 +27,6 @@
 
 # author: Wim Meeussen
 
-import roslib; roslib.load_manifest('tf2_kdl')
 import PyKDL
 import rospy
 import tf2_ros

--- a/tf2_ros/src/tf2_ros/buffer.py
+++ b/tf2_ros/src/tf2_ros/buffer.py
@@ -27,7 +27,6 @@
 
 # author: Wim Meeussen
 
-import roslib; roslib.load_manifest('tf2_ros')
 import rospy
 import tf2_py as tf2
 import tf2_ros

--- a/tf2_ros/src/tf2_ros/buffer_client.py
+++ b/tf2_ros/src/tf2_ros/buffer_client.py
@@ -34,8 +34,6 @@
 #* 
 #* Author: Eitan Marder-Eppstein
 #***********************************************************
-PKG = 'tf2_ros'
-import roslib; roslib.load_manifest(PKG)
 import rospy
 import actionlib
 import tf2_py as tf2

--- a/tf2_ros/src/tf2_ros/buffer_interface.py
+++ b/tf2_ros/src/tf2_ros/buffer_interface.py
@@ -29,7 +29,6 @@
 
 from __future__ import print_function
 
-import roslib; roslib.load_manifest('tf2_ros')
 import rospy
 import tf2_py as tf2
 import tf2_ros


### PR DESCRIPTION
Hi, 
'```import roslib; roslib.load_manifest(PKG)```' seems obsolete.
I think this can be safely removed from ``melodic-devel``.
Thanks.
