### PR TITLE
Fix run_tests of tf2_geometry_msgs with kdl in the same workspace

### DIFF
--- a/tf2_geometry_msgs/CMakeLists.txt
+++ b/tf2_geometry_msgs/CMakeLists.txt
@@ -15,8 +15,10 @@ catkin_package(
    CATKIN_DEPENDS  geometry_msgs tf2_ros tf2)
 
 
-include_directories(include
-                    ${catkin_INCLUDE_DIRS}
+include_directories(
+  include
+  ${orocos_kdl_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 link_directories(${orocos_kdl_LIBRARY_DIRS})


### PR DESCRIPTION
The tests fail to compile with the following error.
```
src/geometry2/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h:47:10: fatal error: kdl/frames.hpp: No such file or directory
 #include <kdl/frames.hpp>
          ^~~~~~~~~~~~~~~~
```
The include path of orocos_kdl is found correctly, but not passed to the compilation of the tests. This commit fixes that.

Steps to reproduce:
```sh
docker run -it ros:melodic

apt update && apt install -y python-catkin-tools

mkdir -p catkin_ws/src
cd catkin_ws
catkin init
cd src

git clone https://github.com/ros/geometry2.git
git clone https://github.com/orocos/orocos_kinematics_dynamics.git


rosdep install --from-path . -iy

catkin build
catkin run_tests tf2_geometry_msgs
```