### PR TITLE
Always call catkin_package() in test_tf2

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -2,20 +2,19 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(test_tf2)
 
-if(NOT CATKIN_ENABLE_TESTING)
-  return()
-endif()
-
 find_package(catkin REQUIRED COMPONENTS rosconsole roscpp rostest tf tf2 tf2_bullet tf2_ros tf2_geometry_msgs tf2_kdl tf2_msgs)
 find_package(Boost REQUIRED COMPONENTS thread)
 find_package(orocos_kdl REQUIRED)
 
+catkin_package()
+
+if(NOT CATKIN_ENABLE_TESTING)
+  return()
+endif()
 
 include_directories(${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ${orocos_kdl_INCLUDE_DIRS})
 
 link_directories(${orocos_kdl_LIBRARY_DIRS})
-
-catkin_package()
 
 catkin_add_gtest(buffer_core_test test/buffer_core_test.cpp)
 target_link_libraries(buffer_core_test ${Boost_LIBRARIES} ${catkin_LIBRARIES} ${orocos_kdl_LIBRARIES})


### PR DESCRIPTION
If `CATKIN_ENABLE_TESTING` is unset this package stops configuring early without calling `cakin_package()`. When this happens no setup scripts are written for `test_tf2`. This prevents `catkin_make_isolated` from building a workspace containing `test_tf2` without `CATKIN_ENABLE_TESTING` because it errors when it gets to this package.

```

==> Processing catkin package: 'test_tf2'
==> Creating build directory: 'build_isolated/test_tf2'
==> Building with env: '/home/sloretz/ws/noetic/devel_isolated/tf2_kdl/env.sh'
==> cmake /home/sloretz/ws/noetic/src/geometry2/test_tf2 -DCATKIN_DEVEL_PREFIX=/home/sloretz/ws/noetic/devel_isolated/test_tf2 -DCMAKE_INSTALL_PREFIX=/home/sloretz/ws/noetic/install_isolated -G Unix Makefiles in '/home/sloretz/ws/noetic/build_isolated/test_tf2'
-- The C compiler identification is GNU 8.3.0
-- The CXX compiler identification is GNU 8.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    CATKIN_DEVEL_PREFIX


-- Build files have been written to: /home/sloretz/ws/noetic/build_isolated/test_tf2
==> make -j8 -l8 in '/home/sloretz/ws/noetic/build_isolated/test_tf2'
Unhandled exception of type 'RuntimeError':
Traceback (most recent call last):
  File "src/catkin/bin/../python/catkin/builder.py", line 1048, in build_workspace_isolated
    number=index + 1, of=len(ordered_packages)
  File "src/catkin/bin/../python/catkin/builder.py", line 744, in build_package
    "'\n  This sometimes occurs when a non-catkin package is "
RuntimeError: No env.sh file generated at: '/home/sloretz/ws/noetic/devel_isolated/test_tf2/env.sh'
  This sometimes occurs when a non-catkin package is interpreted as a catkin package.
  This can also occur when the cmake cache is stale, try --force-cmake.
<== Failed to process package 'test_tf2': 
  No env.sh file generated at: '/home/sloretz/ws/noetic/devel_isolated/test_tf2/env.sh'
  This sometimes occurs when a non-catkin package is interpreted as a catkin package.
  This can also occur when the cmake cache is stale, try --force-cmake.
Command failed, exiting.
```