### PR TITLE
Update shebang and add launch prefixes for python3 support

### DIFF
--- a/test_tf2/test/buffer_client_tester.launch
+++ b/test_tf2/test/buffer_client_tester.launch
@@ -1,5 +1,6 @@
 <launch>
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub" args="5 6 7 0 0 0 1 a b" />
   <node name="test_buffer_server" pkg="test_tf2" type="test_buffer_server" output="screen" />
-  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
+  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text"/>
+  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client.py" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
 </launch>

--- a/test_tf2/test/buffer_client_tester.launch
+++ b/test_tf2/test/buffer_client_tester.launch
@@ -2,5 +2,4 @@
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub" args="5 6 7 0 0 0 1 a b" />
   <node name="test_buffer_server" pkg="test_tf2" type="test_buffer_server" output="screen" />
   <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text"/>
-  <test test-name="test_buffer_client_test_py" pkg="test_tf2" type="test_buffer_client.py" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
 </launch>

--- a/test_tf2/test/buffer_client_tester.launch
+++ b/test_tf2/test/buffer_client_tester.launch
@@ -1,5 +1,5 @@
 <launch>
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub" args="5 6 7 0 0 0 1 a b" />
   <node name="test_buffer_server" pkg="test_tf2" type="test_buffer_server" output="screen" />
-  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text" />
+  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
 </launch>

--- a/test_tf2/test/buffer_client_tester.launch
+++ b/test_tf2/test/buffer_client_tester.launch
@@ -2,5 +2,5 @@
   <node pkg="tf2_ros" type="static_transform_publisher" name="test_static_pub" args="5 6 7 0 0 0 1 a b" />
   <node name="test_buffer_server" pkg="test_tf2" type="test_buffer_server" output="screen" />
   <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client" args="--text"/>
-  <test test-name="test_buffer_client_test" pkg="test_tf2" type="test_buffer_client.py" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
+  <test test-name="test_buffer_client_test_py" pkg="test_tf2" type="test_buffer_client.py" args="--text" launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
 </launch>

--- a/test_tf2/test/static_publisher.launch
+++ b/test_tf2/test/static_publisher.launch
@@ -29,5 +29,6 @@
 
   <test test-name="test_static_publisher_py"
         pkg="test_tf2"
-        type="test_static_publisher.py"/>
+        type="test_static_publisher.py"
+        launch-prefix="python$(env ROS_PYTHON_VERSION)"/>
 </launch>

--- a/test_tf2/test/test_buffer_client.py
+++ b/test_tf2/test/test_buffer_client.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 #***********************************************************
 #* Software License Agreement (BSD License)
 #*

--- a/test_tf2/test/test_convert.py
+++ b/test_tf2/test/test_convert.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 #***********************************************************
 #* Software License Agreement (BSD License)
 #*

--- a/test_tf2/test/test_static_publisher.py
+++ b/test_tf2/test/test_static_publisher.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python
 #***********************************************************
 #* Software License Agreement (BSD License)
 #*


### PR DESCRIPTION
Caught in https://github.com/ros-infrastructure/ros_buildfarm_config/pull/151