### PR TITLE
Don't insert a TF frame if one of the same timestamp already exists, instead just overwrite it.

### DIFF
--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -213,11 +213,12 @@ void setupTree(tf2::BufferCore& mBC, const std::string& mode, const ros::Time & 
         else
           ts.header.stamp = ros::Time();
 
-        ts.header.frame_id = frame_prefix + frames[i-1];
+	ts.child_frame_id = frame_prefix + frames[i];
         if (i > 1)
-          ts.child_frame_id = frame_prefix + frames[i];
-        else
-          ts.child_frame_id = frames[i]; // connect first frame
+	  ts.header.frame_id = frame_prefix + frames[i-1];
+	else
+	  ts.header.frame_id = frames[i-1];
+
         EXPECT_TRUE(mBC.setTransform(ts, "authority"));
         if (interpolation_space > ros::Duration())
         {

--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -213,11 +213,11 @@ void setupTree(tf2::BufferCore& mBC, const std::string& mode, const ros::Time & 
         else
           ts.header.stamp = ros::Time();
 
-	ts.child_frame_id = frame_prefix + frames[i];
+        ts.child_frame_id = frame_prefix + frames[i];
         if (i > 1)
-	  ts.header.frame_id = frame_prefix + frames[i-1];
-	else
-	  ts.header.frame_id = frames[i-1];
+          ts.header.frame_id = frame_prefix + frames[i-1];
+        else
+          ts.header.frame_id = frames[i-1];
 
         EXPECT_TRUE(mBC.setTransform(ts, "authority"));
         if (interpolation_space > ros::Duration())

--- a/tf2/include/tf2/time_cache.h
+++ b/tf2/include/tf2/time_cache.h
@@ -60,7 +60,7 @@ public:
   virtual bool getData(ros::Time time, TransformStorage & data_out, std::string* error_str = 0)=0; //returns false if data unavailable (should be thrown as lookup exception
 
   /** \brief Insert data into the cache */
-  virtual bool insertData(const TransformStorage& new_data)=0;
+  virtual bool insertData(const TransformStorage& new_data, std::string* error_str = 0)=0;
 
   /** @brief Clear the list of stored values */
   virtual void clearList()=0;
@@ -104,7 +104,7 @@ class TimeCache : public TimeCacheInterface
   /// Virtual methods
 
   virtual bool getData(ros::Time time, TransformStorage & data_out, std::string* error_str = 0);
-  virtual bool insertData(const TransformStorage& new_data);
+  virtual bool insertData(const TransformStorage& new_data, std::string* error_str = 0);
   virtual void clearList();
   virtual CompactFrameID getParent(ros::Time time, std::string* error_str);
   virtual P_TimeAndFrameID getLatestTimeAndParent();
@@ -141,7 +141,7 @@ class StaticCache : public TimeCacheInterface
   /// Virtual methods
 
   virtual bool getData(ros::Time time, TransformStorage & data_out, std::string* error_str = 0); //returns false if data unavailable (should be thrown as lookup exception
-  virtual bool insertData(const TransformStorage& new_data);
+  virtual bool insertData(const TransformStorage& new_data, std::string* error_str = 0);
   virtual void clearList();
   virtual CompactFrameID getParent(ros::Time time, std::string* error_str);
   virtual P_TimeAndFrameID getLatestTimeAndParent();

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -275,7 +275,7 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
     }
     else
     {
-      CONSOLE_BRIDGE_logWarn(error_string.c_str(), stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      CONSOLE_BRIDGE_logWarn((error_string+" for frame %s at time %lf according to authority %s").c_str(), stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
       return false;
     }
   }

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -268,13 +268,14 @@ bool BufferCore::setTransform(const geometry_msgs::TransformStamped& transform_i
     if (frame == NULL)
       frame = allocateFrame(frame_number, is_static);
 
-    if (frame->insertData(TransformStorage(stripped, lookupOrInsertFrameNumber(stripped.header.frame_id), frame_number)))
+    std::string error_string;
+    if (frame->insertData(TransformStorage(stripped, lookupOrInsertFrameNumber(stripped.header.frame_id), frame_number), &error_string))
     {
       frame_authority_[frame_number] = authority;
     }
     else
     {
-      CONSOLE_BRIDGE_logWarn("TF_OLD_DATA ignoring data from the past for frame %s at time %g according to authority %s\nPossible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained", stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
+      CONSOLE_BRIDGE_logWarn(error_string.c_str(), stripped.child_frame_id.c_str(), stripped.header.stamp.toSec(), authority.c_str());
       return false;
     }
   }

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -261,7 +261,10 @@ bool TimeCache::insertData(const TransformStorage& new_data)
       break;
     storage_it++;
   }
-  storage_.insert(storage_it, new_data);
+  if (storage_it->stamp_ == new_data.stamp_)
+    *storage_it = new_data;
+  else
+    storage_.insert(storage_it, new_data);
 
   pruneList();
   return true;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -252,9 +252,9 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
     {
       if (error_str)
       {
-	std::stringstream ss;
-	ss << "TF_OLD_DATA ignoring data from the past (Possible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained)";
-	*error_str = ss.str();
+        std::stringstream ss;
+        ss << "TF_OLD_DATA ignoring data from the past (Possible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained)";
+        *error_str = ss.str();
       }
       return false;
     }

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -270,11 +270,11 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
   if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
   {
     if (error_str)
-      {
-	std::stringstream ss;
-	ss << "TF_REPEATED_DATA ignoring data with redundant timestamp";
-	*error_str = ss.str();
-      }
+    {
+      std::stringstream ss;
+      ss << "TF_REPEATED_DATA ignoring data with redundant timestamp";
+      *error_str = ss.str();
+    }
     return false;
   }
   else

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -242,7 +242,7 @@ CompactFrameID TimeCache::getParent(ros::Time time, std::string* error_str)
   return p_temp_1->frame_id_;
 }
 
-bool TimeCache::insertData(const TransformStorage& new_data)
+bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_str)
 {
   L_TransformStorage::iterator storage_it = storage_.begin();
 
@@ -250,6 +250,12 @@ bool TimeCache::insertData(const TransformStorage& new_data)
   {
     if (storage_it->stamp_ > new_data.stamp_ + max_storage_time_)
     {
+      if (error_str)
+      {
+	std::stringstream ss;
+	ss << "TF_OLD_DATA ignoring data from the past for frame %s at time %lf according to authority %s\nPossible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained";
+	*error_str = ss.str();
+      }
       return false;
     }
   }
@@ -263,7 +269,13 @@ bool TimeCache::insertData(const TransformStorage& new_data)
   }
   if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
   {
-    return true;
+    if (error_str)
+      {
+	std::stringstream ss;
+	ss << "TF_REPEATED_DATA ignoring data with redundant timestamp for frame %s at time %lf according to authority %s";
+	*error_str = ss.str();
+      }
+    return false;
   }
   else
   {

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -261,7 +261,7 @@ bool TimeCache::insertData(const TransformStorage& new_data)
       break;
     storage_it++;
   }
-  if (storage_it->stamp_ == new_data.stamp_)
+  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
     *storage_it = new_data;
   else
     storage_.insert(storage_it, new_data);

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -262,9 +262,13 @@ bool TimeCache::insertData(const TransformStorage& new_data)
     storage_it++;
   }
   if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
-    *storage_it = new_data;
+  {
+    return true;
+  }
   else
+  {
     storage_.insert(storage_it, new_data);
+  }
 
   pruneList();
   return true;

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -253,7 +253,7 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
       if (error_str)
       {
 	std::stringstream ss;
-	ss << "TF_OLD_DATA ignoring data from the past for frame %s at time %lf according to authority %s\nPossible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained";
+	ss << "TF_OLD_DATA ignoring data from the past (Possible reasons are listed at http://wiki.ros.org/tf/Errors%%20explained)";
 	*error_str = ss.str();
       }
       return false;
@@ -272,7 +272,7 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
     if (error_str)
       {
 	std::stringstream ss;
-	ss << "TF_REPEATED_DATA ignoring data with redundant timestamp for frame %s at time %lf according to authority %s";
+	ss << "TF_REPEATED_DATA ignoring data with redundant timestamp";
 	*error_str = ss.str();
       }
     return false;

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -45,7 +45,7 @@ bool StaticCache::getData(ros::Time time, TransformStorage & data_out, std::stri
   return true;
 };
 
-bool StaticCache::insertData(const TransformStorage& new_data)
+bool StaticCache::insertData(const TransformStorage& new_data, std::string* error_str)
 {
   storage_ = new_data;
   return true;


### PR DESCRIPTION
So, we ran into an issue with ROS on a project (still on kinetic due to legacy robot issues, but this applies to melodic too, so here's a melodic PR).

Generally, if a node is broadcasting TF data based on other incoming frames and/or other information, and something goes wrong, it will stop publishing data. But we ran into a scenario where something went wrong in a node, and it kept broadcasting the same TF data with the same timestamp, forever. When this happened, we noticed that all nodes with a tf listener started immediately consuming more and more memory.

In looking into this, it is clear that when storing an incoming TF in the tf2 listener code, that if a frame between parent and child exists with the same timestamp, that the incoming data is not ignored, nor does it overwrite the previous frame, but it gets inserted next to the existing frame with the same timestamp, so that now there are multiple transforms between the same two frames with the same timestamp.

I added some debug console outputs and a small publisher node and a node that just makes a tf listener and spins. This proved that the storage for tf listener does indeed grow infinitely so long as no newer data comes in that is more than max_duration (10 seconds) to force these to be pruned.

The fix is VERY simple, and has been tested with the stand alone programs. where previously the size of storage_ grew without bound when sending the exact same message in a loop, but now remains size 1 for that parent/child transform.