### PR TITLE
malcolm: add depends tf2 to catkin_package

### DIFF
--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -30,7 +30,7 @@ include_directories(include
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS EIGEN3)
+  DEPENDS EIGEN3 tf2)
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/tf2_eigen/CMakeLists.txt
+++ b/tf2_eigen/CMakeLists.txt
@@ -30,7 +30,8 @@ include_directories(include
 
 catkin_package(
   INCLUDE_DIRS include
-  DEPENDS EIGEN3 tf2)
+  CATKIN_DEPENDS tf2
+  DEPENDS EIGEN3)
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})


### PR DESCRIPTION
Hi,

This push adds dependency on tf2 to catkin_package.

I needed to add that dependecy to compile the package under my source install on Fedora.

Best,