### PR TITLE
do_transform_cloud now maintains the original order of the point cloud

### DIFF
--- a/tf2_sensor_msgs/src/tf2_sensor_msgs/tf2_sensor_msgs.py
+++ b/tf2_sensor_msgs/src/tf2_sensor_msgs/tf2_sensor_msgs.py
@@ -55,6 +55,6 @@ def do_transform_cloud(cloud, transform):
     for p_in in read_points(cloud):
         p_out = t_kdl * PyKDL.Vector(p_in[0], p_in[1], p_in[2])
         points_out.append((p_out[0], p_out[1], p_out[2]) + p_in[3:])
-    res = create_cloud(transform.header, cloud.fields, points_out)
+    res = create_cloud(transform.header, cloud.fields, points_out, cloud.height, cloud.width)
     return res
 tf2_ros.TransformRegistration().add(PointCloud2, do_transform_cloud)


### PR DESCRIPTION
The faction that transforms the point cloud should keep the original order and shape of the message.
To work it requires an updated version of the "create_cloud" function proposed here:
https://github.com/ros/common_msgs/pull/157
