### PR TITLE
[windows][melodic] more portable fixes.

### DIFF
--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -31,7 +31,6 @@
 #include <gtest/gtest.h>
 #include <tf2/buffer_core.h>
 #include "tf2/exceptions.h"
-//#include <sys/time.h>
 #include <ros/ros.h>
 #include "LinearMath/btVector3.h"
 #include "LinearMath/btTransform.h"

--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -27,10 +27,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cmath>
 #include <gtest/gtest.h>
 #include <tf2/buffer_core.h>
 #include "tf2/exceptions.h"
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <ros/ros.h>
 #include "LinearMath/btVector3.h"
 #include "LinearMath/btTransform.h"
@@ -288,7 +289,7 @@ TEST(BufferCore_setTransform, NoInsertWithNan)
   tranStamped.header.frame_id = "same_frame";
   tranStamped.child_frame_id = "other_frame";
   EXPECT_TRUE(mBC.setTransform(tranStamped, "authority"));
-  tranStamped.transform.translation.x = 0.0/0.0;
+  tranStamped.transform.translation.x = std::nan("");
   EXPECT_TRUE(std::isnan(tranStamped.transform.translation.x));
   EXPECT_FALSE(mBC.setTransform(tranStamped, "authority"));
 

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -31,7 +31,7 @@
 #include <tf2/buffer_core.h>
 #include "tf2/exceptions.h"
 #include <tf2_ros/static_transform_broadcaster.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <ros/ros.h>
 #include "rostest/permuter.h"
 

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -31,7 +31,6 @@
 #include <tf2/buffer_core.h>
 #include "tf2/exceptions.h"
 #include <tf2_ros/static_transform_broadcaster.h>
-//#include <sys/time.h>
 #include <ros/ros.h>
 #include "rostest/permuter.h"
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -29,7 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <tf2/time_cache.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include "tf2/LinearMath/Quaternion.h"
 #include <stdexcept>
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include <tf2/time_cache.h>
-//#include <sys/time.h>
 #include "tf2/LinearMath/Quaternion.h"
 #include <stdexcept>
 

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include <tf2/buffer_core.h>
-//#include <sys/time.h>
 #include <ros/time.h>
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -29,7 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <tf2/buffer_core.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <ros/time.h>
 #include "tf2/LinearMath/Vector3.h"
 #include "tf2/exceptions.h"

--- a/tf2/test/static_cache_test.cpp
+++ b/tf2/test/static_cache_test.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include <tf2/time_cache.h>
-//#include <sys/time.h>
 #include <stdexcept>
 
 #include <geometry_msgs/TransformStamped.h>

--- a/tf2/test/static_cache_test.cpp
+++ b/tf2/test/static_cache_test.cpp
@@ -29,7 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <tf2/time_cache.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <stdexcept>
 
 #include <geometry_msgs/TransformStamped.h>

--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -9,6 +9,9 @@ if(NOT bullet_FOUND)
     # windows build bullet3 doesn't come with pkg-config by default and it only comes with CMake config files
     # so pkg_check_modules will fail
     find_package(bullet REQUIRED)
+
+    # https://github.com/bulletphysics/bullet3/blob/master/BulletConfig.cmake.in
+    set(bullet_INCLUDE_DIRS "${BULLET_INCLUDE_DIRS}")
 endif()
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2)

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -29,7 +29,7 @@
 
 #include <gtest/gtest.h>
 #include <tf2_ros/transform_listener.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 
 using namespace tf2;
 

--- a/tf2_ros/test/listener_unittest.cpp
+++ b/tf2_ros/test/listener_unittest.cpp
@@ -29,7 +29,6 @@
 
 #include <gtest/gtest.h>
 #include <tf2_ros/transform_listener.h>
-//#include <sys/time.h>
 
 using namespace tf2;
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -37,6 +37,8 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
 
 
 void spin_for_a_second()
@@ -44,7 +46,7 @@ void spin_for_a_second()
   ros::spinOnce();
   for (uint8_t i = 0; i < 10; ++i)
   {
-    usleep(100);
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
     ros::spinOnce();
   }
 }

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -32,7 +32,6 @@
 #include <chrono>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
-//#include <sys/time.h>
 #include <rosgraph_msgs/Clock.h>
 
 using namespace tf2;

--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -28,9 +28,11 @@
  */
 
 #include <gtest/gtest.h>
+#include <thread>
+#include <chrono>
 #include <tf2_ros/transform_broadcaster.h>
 #include <tf2_ros/transform_listener.h>
-#include <sys/time.h>
+//#include <sys/time.h>
 #include <rosgraph_msgs/Clock.h>
 
 using namespace tf2;
@@ -40,7 +42,7 @@ void spin_for_a_second()
   ros::spinOnce();
   for (uint8_t i = 0; i < 10; ++i)
   {
-    usleep(100);
+    std::this_thread::sleep_for(std::chrono::microseconds(100));
     ros::spinOnce();
   }
 }


### PR DESCRIPTION
* Remove unused include file: `<sys/time.h>`.
* Use c+11 `std::nan()` to replace `0.0/0.0`.
* Use c+11 `std::thread::sleep_for` to replace `usleep`.
* Fix `find_package(bullet)` usage.