### PR TITLE
[windows][melodic] Fix ambiguous call for tf2::convert on MSVC

### DIFF
--- a/test_tf2/CMakeLists.txt
+++ b/test_tf2/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(test_tf2)
 
-find_package(catkin REQUIRED COMPONENTS rosconsole roscpp rostest tf tf2 tf2_bullet tf2_ros tf2_geometry_msgs tf2_kdl tf2_msgs)
+find_package(catkin REQUIRED COMPONENTS rosconsole roscpp rostest tf tf2 tf2_bullet tf2_ros tf2_geometry_msgs tf2_kdl tf2_msgs tf2_eigen)
 find_package(Boost REQUIRED COMPONENTS thread)
 find_package(orocos_kdl REQUIRED)
 

--- a/test_tf2/package.xml
+++ b/test_tf2/package.xml
@@ -23,6 +23,7 @@
   <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>tf2_kdl</build_depend>
   <build_depend>tf2_msgs</build_depend>
+  <build_depend>tf2_eigen</build_depend>
 
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
@@ -34,6 +35,7 @@
   <run_depend>tf2_geometry_msgs</run_depend>
   <run_depend>tf2_kdl</run_depend>
   <run_depend>tf2_msgs</run_depend>
+  <run_depend>tf2_eigen</run_depend>
 
   <test_depend>rosunit</test_depend>
   <test_depend>rosbash</test_depend>

--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -39,6 +39,7 @@
 #include <tf2_kdl/tf2_kdl.h>
 #include <tf2_bullet/tf2_bullet.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_eigen/tf2_eigen.h>
 #include <ros/time.h>
 
 TEST(tf2Convert, kdlToBullet)
@@ -96,6 +97,18 @@ TEST(tf2Convert, kdlBulletROSConversions)
   EXPECT_NEAR(b1.y(), b4.y(), epsilon);
   EXPECT_NEAR(b1.z(), b4.z(), epsilon);
 } 
+
+TEST(tf2Convert, ConvertTf2Quaternion)
+{
+  tf2::Quaternion tq(1,2,3,4);
+  Eigen::Quaterniond eq;
+  tf2::convert(tq, eq);
+
+  EXPECT_EQ(tq.w(), eq.w());
+  EXPECT_EQ(tq.x(), eq.x());
+  EXPECT_EQ(tq.y(), eq.y());
+  EXPECT_EQ(tq.z(), eq.z());
+}
 
 int main(int argc, char** argv)
 {

--- a/tf2/include/tf2/impl/convert.h
+++ b/tf2/include/tf2/impl/convert.h
@@ -55,21 +55,33 @@ template <>
 template <typename A, typename B>
 inline void Converter<true, false>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
+  tf2::fromMsg(a, b);
+#else
   fromMsg(a, b);
+#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, true>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
+  b = tf2::toMsg(a);
+#else
   b = toMsg(a);
+#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, false>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
+  tf2::fromMsg(tf2::toMsg(a), b);
+#else
   fromMsg(toMsg(a), b);
+#endif
 }
 
 }

--- a/tf2/include/tf2/impl/convert.h
+++ b/tf2/include/tf2/impl/convert.h
@@ -55,33 +55,21 @@ template <>
 template <typename A, typename B>
 inline void Converter<true, false>::convert(const A& a, B& b)
 {
-#ifdef _MSC_VER
   tf2::fromMsg(a, b);
-#else
-  fromMsg(a, b);
-#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, true>::convert(const A& a, B& b)
 {
-#ifdef _MSC_VER
   b = tf2::toMsg(a);
-#else
-  b = toMsg(a);
-#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, false>::convert(const A& a, B& b)
 {
-#ifdef _MSC_VER
   tf2::fromMsg(tf2::toMsg(a), b);
-#else
-  fromMsg(toMsg(a), b);
-#endif
 }
 
 }

--- a/tf2/include/tf2/impl/convert.h
+++ b/tf2/include/tf2/impl/convert.h
@@ -55,21 +55,33 @@ template <>
 template <typename A, typename B>
 inline void Converter<true, false>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
   tf2::fromMsg(a, b);
+#else
+  fromMsg(a, b);
+#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, true>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
   b = tf2::toMsg(a);
+#else
+  b = toMsg(a);
+#endif
 }
 
 template <>
 template <typename A, typename B>
 inline void Converter<false, false>::convert(const A& a, B& b)
 {
+#ifdef _MSC_VER
   tf2::fromMsg(tf2::toMsg(a), b);
+#else
+  fromMsg(toMsg(a), b);
+#endif
 }
 
 }


### PR DESCRIPTION
This is another attempt to rework - `ambiguous call for tf2::convert on MSVC`. Here is the previous attempt #367.

## Problem

When building a downstream project (MoveIt), it fails to compile and reports `'tf2::fromMsg': ambiguous call to overloaded function`.

```no-highlight
wrap_python_move_group.cpp
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\py_bindings_tools\include\moveit/py_bindings_tools/serialize_msg.h(69): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\move_group_interface\src\wrap_python_move_group.cpp(97): note: see reference to function template instantiation 'void moveit::py_bindings_tools::deserializeMsg<geometry_msgs::Pose>(const std::string &,T &)' being compiled
with
[
T=geometry_msgs::Pose
]
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(54): note: see reference to class template instantiation 'boost::arg<9>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(53): note: see reference to class template instantiation 'boost::arg<8>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(52): note: see reference to class template instantiation 'boost::arg<7>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(51): note: see reference to class template instantiation 'boost::arg<6>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(50): note: see reference to class template instantiation 'boost::arg<5>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(49): note: see reference to class template instantiation 'boost::arg<4>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(48): note: see reference to class template instantiation 'boost::arg<3>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(47): note: see reference to class template instantiation 'boost::arg<2>' being compiled
C:\opt\rosdeps\x64\include\boost-1_66\boost/bind/placeholders.hpp(46): note: see reference to class template instantiation 'boost::arg<1>' being compiled
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\py_bindings_tools\include\moveit/py_bindings_tools/serialize_msg.h(58): warning C4267: 'argument': conversion from 'size_t' to 'uint32_t', possible loss of data
D:\a\1\a\_ws\src\moveit\moveit_ros\planning_interface\move_group_interface\src\wrap_python_move_group.cpp(138): note: see reference to function template instantiation 'std::string moveit::py_bindings_tools::serializeMsg<moveit_msgs::RobotState>(const T &)' being compiled
with
[
T=moveit_msgs::RobotState
]
C:\opt\ros\melodic\x64\include\tf2/impl/convert.h(72): error C2668: 'tf2::fromMsg': ambiguous call to overloaded function
```

## Resolution
For MSVC, it requires to be explicit on what's the namespace of the overloaded templated (and non-templated functions). On the flip side, for GCC\Clang, specifying the namespace requires the overloaded functions to be forward-declared and which would mean to shuffle the header inclusion by different order.

Making all the overloaded functions visible before `tf2::impl::convert` gets defined looks to me a more proper fix. However, given `tf2` is a [relatively fundamental package][tf2 deps] in ROS stack, I am hesitate to do much extensive header refactoring. So I am simply using compiler conditional guard to mitigate the build break (and added a test case to synthesize the MoveIt usage).

[tf2 deps]: https://index.ros.org/p/tf2/github-ros-geometry2/#melodic-deps
