### PR TITLE
Use text=True to fix Python 3 test failure

### DIFF
--- a/test_tf2/test/test_static_publisher.py
+++ b/test_tf2/test/test_static_publisher.py
@@ -63,7 +63,7 @@ class TestStaticPublisher(unittest.TestCase):
         cmd = 'rosrun tf2_ros static_transform_publisher'
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             ret = subprocess.check_output(
-                cmd.split(' '), stderr=subprocess.STDOUT)
+                cmd.split(' '), stderr=subprocess.STDOUT, text=True)
         self.assertEqual(255, cm.exception.returncode)
         self.assertIn('not having the right number of arguments',
                       cm.exception.output)
@@ -73,7 +73,7 @@ class TestStaticPublisher(unittest.TestCase):
         cmd = 'rosrun tf2_ros static_transform_publisher /test_tf2/tf_null'
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             ret = subprocess.check_output(
-                cmd.split(' '), stderr=subprocess.STDOUT)
+                cmd.split(' '), stderr=subprocess.STDOUT, text=True)
 
         self.assertEqual(255, cm.exception.returncode)
         self.assertIn('Could not read TF', cm.exception.output)
@@ -83,7 +83,7 @@ class TestStaticPublisher(unittest.TestCase):
         cmd = 'rosrun tf2_ros static_transform_publisher /test_tf2/tf_invalid'
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             ret = subprocess.check_output(
-                cmd.split(' '), stderr=subprocess.STDOUT)
+                cmd.split(' '), stderr=subprocess.STDOUT, text=True)
 
         self.assertEqual(255, cm.exception.returncode)
         self.assertIn('Could not validate XmlRpcC', cm.exception.output)


### PR DESCRIPTION
Fixes #422

This fixes a test failure using Python 3. The `text` keyword argument is only available in Python 3.7+, but that should be fine since this is the `noetic-devel` branch and Noetic targets Python 3.7 minimum.

```
[test_tf2.rosunit-test_static_publisher_py/test_publisher_invalid_param][ERROR]-
a bytes-like object is required, not 'str'
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/sloretz/ws/noetic-misc/src/geometry2/test_tf2/test/test_static_publisher.py", line 89, in test_publisher_invalid_param
    self.assertIn('Could not validate XmlRpcC', cm.exception.output)
  File "/usr/lib/python3.8/unittest/case.py", line 1176, in assertIn
    if member not in container:
--------------------------------------------------------------------------------

[test_tf2.rosunit-test_static_publisher_py/test_publisher_no_args][ERROR]-------
a bytes-like object is required, not 'str'
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/sloretz/ws/noetic-misc/src/geometry2/test_tf2/test/test_static_publisher.py", line 68, in test_publisher_no_args
    self.assertIn('not having the right number of arguments',
  File "/usr/lib/python3.8/unittest/case.py", line 1176, in assertIn
    if member not in container:
--------------------------------------------------------------------------------

[test_tf2.rosunit-test_static_publisher_py/test_publisher_nonexistent_param][ERROR]
a bytes-like object is required, not 'str'
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/home/sloretz/ws/noetic-misc/src/geometry2/test_tf2/test/test_static_publisher.py", line 79, in test_publisher_nonexistent_param
    self.assertIn('Could not read TF', cm.exception.output)
  File "/usr/lib/python3.8/unittest/case.py", line 1176, in assertIn
    if member not in container:
--------------------------------------------------------------------------------


SUMMARY
 * RESULT: FAIL
 * TESTS: 8
 * ERRORS: 3
 * FAILURES: 0

rostest log file is in /home/sloretz/.ros/log/rostest-728155609c36-11518.log
```