### PR TITLE
Replace kdl packages with rosdep keys

### DIFF
--- a/tf2_geometry_msgs/package.xml
+++ b/tf2_geometry_msgs/package.xml
@@ -13,13 +13,13 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>orocos_kdl</depend>
+  <depend>liborocos-kdl-dev</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
-  <build_depend>python_orocos_kdl</build_depend>
+  <build_depend>python3-pykdl</build_depend>
  
-  <exec_depend>python_orocos_kdl</exec_depend>
+  <exec_depend>python3-pykdl</exec_depend>
 
   <test_depend>ros_environment</test_depend>
   <test_depend>rostest</test_depend>

--- a/tf2_kdl/package.xml
+++ b/tf2_kdl/package.xml
@@ -17,7 +17,7 @@
 
   <build_export_depend>eigen</build_export_depend> <!-- needed by kdl internally -->
 
-  <depend>orocos_kdl</depend>
+  <depend>liborocos-kdl-dev</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 

--- a/tf2_sensor_msgs/package.xml
+++ b/tf2_sensor_msgs/package.xml
@@ -19,7 +19,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
 
-  <exec_depend>python_orocos_kdl</exec_depend>
+  <exec_depend>python3-pykdl</exec_depend>
   <exec_depend>rospy</exec_depend>
 
   <build_export_depend>eigen</build_export_depend>


### PR DESCRIPTION
I tested these packages using a system install of `liborocos-kdl-dev` and `python3-pykdl` on Debian Buster and Ubuntu Focal and the tests seem to pass. This PR replaces the orocos KDL ROS packages with to-be-added rosdep keys.

See also ros/rosdistro#23841