### PR TITLE
[Noetic] Add tf2::Stamped<T>::operator=() to fix warnings downstream

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -50,4 +50,8 @@ target_link_libraries(speed_test tf2  ${console_bridge_LIBRARIES})
 add_dependencies(tests speed_test)
 add_dependencies(tests ${catkin_EXPORTED_TARGETS})
 
+catkin_add_gtest(test_transform_datatypes test/test_transform_datatypes.cpp)
+target_link_libraries(test_transform_datatypes tf2  ${console_bridge_LIBRARIES})
+add_dependencies(test_transform_datatypes ${catkin_EXPORTED_TARGETS})
+
 endif()

--- a/tf2/include/tf2/transform_datatypes.h
+++ b/tf2/include/tf2/transform_datatypes.h
@@ -58,6 +58,16 @@ class Stamped : public T{
     T (s),
     stamp_(s.stamp_),
     frame_id_(s.frame_id_) {}
+
+  /** Copy assignment operator */
+  Stamped<T> & operator=(const Stamped<T> & rhs)
+  {
+    T::operator=(rhs);
+    stamp_ = rhs.stamp_;
+    frame_id_ = rhs.frame_id_;
+    return *this;
+  }
+
   
   /** Set the data element */
   void setData(const T& input){*static_cast<T*>(this) = input;};

--- a/tf2/test/test_transform_datatypes.cpp
+++ b/tf2/test/test_transform_datatypes.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <gtest/gtest.h>
+
+#include "tf2/transform_datatypes.h"
+
+#include <string>
+
+
+TEST(Stamped, assignment)
+{
+  tf2::Stamped<std::string> first("foobar", ros::Time(0), "my_frame_id");
+  tf2::Stamped<std::string> second("baz", ros::Time(0), "my_frame_id");
+
+  EXPECT_NE(second, first);
+  second = first;
+  EXPECT_EQ(second, first);
+}
+
+TEST(Stamped, setData)
+{
+  tf2::Stamped<std::string> first("foobar", ros::Time(0), "my_frame_id");
+  tf2::Stamped<std::string> second("baz", ros::Time(0), "my_frame_id");
+
+  EXPECT_NE(second, first);
+  second.setData("foobar");
+  EXPECT_EQ(second, first);
+}
+
+TEST(Stamped, copy_constructor)
+{
+  tf2::Stamped<std::string> first("foobar", ros::Time(0), "my_frame_id");
+  tf2::Stamped<std::string> second(first);
+
+  EXPECT_EQ(second, first);
+}
+
+TEST(Stamped, default_constructor)
+{
+  tf2::Stamped<std::string> first("foobar", ros::Time(0), "my_frame_id");
+  tf2::Stamped<std::string> second;
+
+  EXPECT_NE(second, first);
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::Time::init();
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This fixes compiler warnings in `robot_state_publisher` that come from using `tf2::Stamped<T>`.


```
In file included from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h: In function ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = tf2::Stamped<KDL::Vector>; geometry_msgs::TransformStamped = geometry_msgs::TransformStamped_<std::allocator<void> >]’:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:86:122: warning: implicitly-declared ‘tf2::Stamped<KDL::Vector>& tf2::Stamped<KDL::Vector>::operator=(const tf2::Stamped<KDL::Vector>&)’ is deprecated [-Wdeprecated-copy]
   86 |     t_out = tf2::Stamped<KDL::Vector>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
      |                                                                                                                          ^
In file included from /opt/ros/noetic/include/tf2/transform_functions.h:35,
                 from /opt/ros/noetic/include/tf2/convert.h:35,
                 from /opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:35,
                 from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2/transform_datatypes.h:57:3: note: because ‘tf2::Stamped<KDL::Vector>’ has user-provided ‘tf2::Stamped<T>::Stamped(const tf2::Stamped<T>&) [with T = KDL::Vector]’
   57 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
In file included from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h: In function ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = tf2::Stamped<KDL::Twist>; geometry_msgs::TransformStamped = geometry_msgs::TransformStamped_<std::allocator<void> >]’:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:134:121: warning: implicitly-declared ‘tf2::Stamped<KDL::Twist>& tf2::Stamped<KDL::Twist>::operator=(const tf2::Stamped<KDL::Twist>&)’ is deprecated [-Wdeprecated-copy]
  134 |     t_out = tf2::Stamped<KDL::Twist>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
      |                                                                                                                         ^
In file included from /opt/ros/noetic/include/tf2/transform_functions.h:35,
                 from /opt/ros/noetic/include/tf2/convert.h:35,
                 from /opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:35,
                 from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2/transform_datatypes.h:57:3: note: because ‘tf2::Stamped<KDL::Twist>’ has user-provided ‘tf2::Stamped<T>::Stamped(const tf2::Stamped<T>&) [with T = KDL::Twist]’
   57 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
In file included from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h: In function ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = tf2::Stamped<KDL::Wrench>; geometry_msgs::TransformStamped = geometry_msgs::TransformStamped_<std::allocator<void> >]’:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:189:122: warning: implicitly-declared ‘tf2::Stamped<KDL::Wrench>& tf2::Stamped<KDL::Wrench>::operator=(const tf2::Stamped<KDL::Wrench>&)’ is deprecated [-Wdeprecated-copy]
  189 |     t_out = tf2::Stamped<KDL::Wrench>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
      |                                                                                                                          ^
In file included from /opt/ros/noetic/include/tf2/transform_functions.h:35,
                 from /opt/ros/noetic/include/tf2/convert.h:35,
                 from /opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:35,
                 from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2/transform_datatypes.h:57:3: note: because ‘tf2::Stamped<KDL::Wrench>’ has user-provided ‘tf2::Stamped<T>::Stamped(const tf2::Stamped<T>&) [with T = KDL::Wrench]’
   57 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
In file included from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h: In function ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = tf2::Stamped<KDL::Frame>; geometry_msgs::TransformStamped = geometry_msgs::TransformStamped_<std::allocator<void> >]’:
/opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:246:121: warning: implicitly-declared ‘tf2::Stamped<KDL::Frame>& tf2::Stamped<KDL::Frame>::operator=(const tf2::Stamped<KDL::Frame>&)’ is deprecated [-Wdeprecated-copy]
  246 |     t_out = tf2::Stamped<KDL::Frame>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
      |                                                                                                                         ^
In file included from /opt/ros/noetic/include/tf2/transform_functions.h:35,
                 from /opt/ros/noetic/include/tf2/convert.h:35,
                 from /opt/ros/noetic/include/tf2_kdl/tf2_kdl.h:35,
                 from /home/sloretz/ws/noetic/src/robot_state_publisher/src/robot_state_publisher.cpp:39:
/opt/ros/noetic/include/tf2/transform_datatypes.h:57:3: note: because ‘tf2::Stamped<KDL::Frame>’ has user-provided ‘tf2::Stamped<T>::Stamped(const tf2::Stamped<T>&) [with T = KDL::Frame]’
   57 |   Stamped(const Stamped<T>& s):
      |   ^~~~~~~
```

*note: I would have pushed this branch to a fork, but sloretz/geometry2 appears to be a fork of `ros2/geometry2` already, and I couldn't open a PR from there to `ros/geometry2` :(*