### PR TITLE
Correctly handle multiple StaticTransformBroadcasters in a single process

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -42,6 +42,7 @@
 namespace tf2_ros
 {
 
+struct StaticTransformBroadcasterImpl;
 
 /** \brief This class provides an easy way to publish coordinate frame transform information.  
  * It will handle all the messaging and stuffing of messages.  And the function prototypes lay out all the 
@@ -63,11 +64,7 @@ public:
   void sendTransform(const std::vector<geometry_msgs::TransformStamped> & transforms);
 
 private:
-  /// Internal reference to ros::Node
-  ros::NodeHandle node_;
-  ros::Publisher publisher_;
-  tf2_msgs::TFMessage net_message_;
-
+  std::shared_ptr<StaticTransformBroadcasterImpl> impl_;
 };
 
 }


### PR DESCRIPTION
As ROS latches only the last message from a given node and topic, when using multiple static broadcasters, only the last message is actually kept. To correctly handle multiple static broadcasters, we need to share the actual publisher instance across all broadcaster instances within a process.
This is done here via a private, shared `impl` pointer.

Originally, I implemented this caching at the application level (i.e. in my rviz plugin). Then I thought, the issue should actually be handled here in `tf`.
Now, I'm even thinking it should be handled at the basic ROS level: whenever there are multiple, latched publishers from a single process, their messages should _all_ be latched.
However, I'm not deep enough into the ros_comm library to judge whether this can be handled as easy as here, where the infrastructure to keep _several_ messages (stamped transforms) was already in place.

I don't care very much on which level this bug will be fixed. I just wanted to point out the issue and a possible solution.

Note that this PR builds on #454.