### PR TITLE
overwrite tf2 cache entry with same timestamp

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -261,9 +261,16 @@ bool TimeCache::insertData(const TransformStorage& new_data)
       break;
     storage_it++;
   }
-  storage_.insert(storage_it, new_data);
+  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
+  {
+    *storage_it = new_data;
+  }
+  else
+  {
+    storage_.insert(storage_it, new_data);
+    pruneList();
+  }
 
-  pruneList();
   return true;
 }
 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -390,13 +390,17 @@ TEST(TimeCache, DuplicateEntries)
   stor.frame_id_ = 3;
   stor.stamp_ = ros::Time().fromNSec(1);
 
+  stor.translation_.setX(1.0);
+
   cache.insertData(stor);
+
+  stor.translation_.setX(2.0);
 
   cache.insertData(stor);
 
 
   cache.getData(ros::Time().fromNSec(1), stor);
-  
+
   //printf(" stor is %f\n", stor.translation_.x());
   EXPECT_TRUE(!std::isnan(stor.translation_.x()));
   EXPECT_TRUE(!std::isnan(stor.translation_.y()));
@@ -405,6 +409,9 @@ TEST(TimeCache, DuplicateEntries)
   EXPECT_TRUE(!std::isnan(stor.rotation_.y()));
   EXPECT_TRUE(!std::isnan(stor.rotation_.z()));
   EXPECT_TRUE(!std::isnan(stor.rotation_.w()));
+
+  EXPECT_EQ(1, cache.getListLength());
+  EXPECT_DOUBLE_EQ(2.0, stor.translation_.x());
 }
 
 int main(int argc, char **argv){


### PR DESCRIPTION
Currently, entries with the same timestamp are all added to `TimeCache`. This might cause the internal list to grow indefinitely, since `pruneList` will not remove any entries.

This PR fixes this problem by overwriting an existing entry with the same timestamp, instead of inserting a new entry in the list.