### PR TITLE
fix shebang line for python3

### DIFF
--- a/tf2_kdl/CMakeLists.txt
+++ b/tf2_kdl/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${GTES
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-install(PROGRAMS scripts/test.py
+catkin_install_python(PROGRAMS scripts/test.py
          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # tf2 echo code Copyright (c) 2018, Lucas Walter
 # transformations.py code Copyright (c) 2006-2017, Christoph Gohlke

--- a/tf2_tools/scripts/view_frames.py
+++ b/tf2_tools/scripts/view_frames.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2008, Willow Garage, Inc.
 # All rights reserved.
 # 


### PR DESCRIPTION
Similar to https://github.com/ros-visualization/rqt_graph/pull/43

Without this change the script cannot be rosrun on Noetic/Focal and results in:
`/usr/bin/env: ‘python’: No such file or directory`

Python scripts need to be installed using `catkin_install_python` for the shebang line to be rewritten to point to python3. More details at https://wiki.ros.org/UsingPython3/SourceCodeChanges#Changing_shebangs


tf2_tools is not a python package so I just updated the shebang line to be point to python3

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>