### PR TITLE
Revert "do not add TF with redundant timestamp"

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -269,13 +269,7 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
   }
   if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
   {
-    if (error_str)
-    {
-      std::stringstream ss;
-      ss << "TF_REPEATED_DATA ignoring data with redundant timestamp";
-      *error_str = ss.str();
-    }
-    return false;
+    return true;
   }
   else
   {

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -267,9 +267,18 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
       break;
     storage_it++;
   }
-  storage_.insert(storage_it, new_data);
 
-  pruneList();
+  // Allow to replace TF with the same timestamp
+  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
+  {
+    *storage_it = new_data;
+  }
+  else
+  {
+    storage_.insert(storage_it, new_data);
+    pruneList();
+  }
+
   return true;
 }
 

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -267,14 +267,7 @@ bool TimeCache::insertData(const TransformStorage& new_data, std::string* error_
       break;
     storage_it++;
   }
-  if (storage_it != storage_.end() && storage_it->stamp_ == new_data.stamp_)
-  {
-    return true;
-  }
-  else
-  {
-    storage_.insert(storage_it, new_data);
-  }
+  storage_.insert(storage_it, new_data);
 
   pruneList();
   return true;

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -407,6 +407,30 @@ TEST(TimeCache, DuplicateEntries)
   EXPECT_TRUE(!std::isnan(stor.rotation_.w()));
 }
 
+TEST(TimeCache, AllowReplaceData)
+{
+  TimeCache cache;
+
+  TransformStorage firstTf;
+  setIdentity(firstTf);
+  firstTf.translation_.setX(0.5);
+  firstTf.frame_id_ = 3;
+  firstTf.stamp_ = ros::Time().fromNSec(1);
+
+  TransformStorage secondTf = firstTf;
+  secondTf.translation_.setX(2.0);
+
+  cache.insertData(firstTf);
+
+  cache.insertData(secondTf);
+
+  TransformStorage stor;
+  cache.getData(ros::Time().fromNSec(1), stor);
+
+  //printf(" stor is %f\n", stor.translation_.x())
+  EXPECT_EQ(stor.translation_, secondTf.translation_);
+}
+
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
Allow one to send a TF with a redundant timestamp to replace it.

Closes #467