### PR TITLE
[noetic] avoid name collision b/t tf2_py and tf2

### DIFF
--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -96,7 +96,7 @@ add_dependencies(tf2_py ${catkin_EXPORTED_TARGETS})
 
 if(WIN32)
   # use .pyd extension on Windows
-  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".pyd")
+  set_target_properties(tf2_py PROPERTIES OUTPUT_NAME "_tf2" SUFFIX ".pyd")
 else()
   set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")


### PR DESCRIPTION
When `tf2_py` and `tf2` are building with a merged space, building `tf2_py` will lead to the following error on Windows:
```
tf2_py.cpp
[100%] Linking CXX shared library C:\workspace\noetic_rel\devel_isolated\bin\_tf2.pyd
LINK Pass 1: command "C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\1426~1.288\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\tf2_py.dir\objects1.rsp /out:C:\workspace\noetic_rel\devel_isolated\bin\_tf2.pyd /implib:C:\workspace\noetic_rel\devel_isolated\lib\tf2.lib /pdb:C:\workspace\noetic_rel\devel_isolated\bin\_tf2.pdb /dll /version:0.0 /machine:x64 /debug /INCREMENTAL /DEF:CMakeFiles\tf2_py.dir\exports.def C:\opt\ros\xxxx\x64\Lib\python38.lib C:\workspace\noetic_rel\devel_isolated\lib\tf2.lib C:\workspace\noetic_rel\devel_isolated\lib\roscpp_serialization.lib C:\workspace\noetic_rel\devel_isolated\lib\rostime.lib C:\workspace\noetic_rel\devel_isolated\lib\cpp_common.lib C:\opt\ros\xxxx\x64\Lib\boost_system-vc140-mt.lib C:\opt\ros\xxxx\x64\Lib\boost_thread-vc140-mt.lib C:\opt\ros\xxxx\x64\Lib\boost_chrono-vc140-mt.lib C:\opt\ros\xxxx\x64\Lib\boost_date_time-vc140-mt.lib C:\opt\ros\xxxx\x64\Lib\boost_atomic-vc140-mt.lib C:\opt\ros\xxxx\x64\lib\console_bridge.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:CMakeFiles\tf2_py.dir/intermediate.manifest CMakeFiles\tf2_py.dir/manifest.res" failed (exit code 1149) with the following output:
LINK : fatal error LNK1149: output filename matches input filename 'C:\workspace\noetic_rel\devel_isolated\lib\tf2.lib'
```

The cause is that the `PREFIX` is not actually propagated to all the generated files such as imported libraries, and the linker is trying to generate the import library of `tf2_py` as `tf2.lib` which has a name collision with `tf2`.

And this pull request is to fix the output name to be more consistent to avoid the collision.

Also, please consider to back-port to `melodic` branch if this change makes sense.