### PR TITLE
Issue a warning when using multiple StaticTransformBroadcasters

### DIFF
--- a/tf2_ros/src/tf2_ros/static_transform_broadcaster.py
+++ b/tf2_ros/src/tf2_ros/static_transform_broadcaster.py
@@ -39,9 +39,14 @@ class StaticTransformBroadcaster(object):
     """
     :class:`StaticTransformBroadcaster` is a convenient way to send static transformation on the ``"/tf_static"`` message topic.
     """
+    already_exists = False
 
     def __init__(self):
         self.pub_tf = rospy.Publisher("/tf_static", TFMessage, queue_size=100, latch=True)
+        if StaticTransformBroadcaster.already_exists:
+            rospy.logwarn("tf2_ros.StaticTransformBroadcaster: Multiple instances not supported, "
+                          "please use only a single StaticTransformBroadcaster per node")
+        StaticTransformBroadcaster.already_exists = True
 
     def sendTransform(self, transform):
         if not isinstance(transform, list):


### PR DESCRIPTION
Mitigates #406 

We ran into an issue where we had multiple `StaticTransformBroadcaster`s per node. And just like [these](https://answers.ros.org/question/261815/how-can-i-access-all-static-tf2-transforms/) [two](https://answers.ros.org/question/287469/unable-to-publish-multiple-static-transformations-using-tf/) questions we had a hard time debugging why the tf tree was broken.

This PR issues a warning is someone tries to do the same.