### PR TITLE
Class BufferCore and class Buffer should be movable

### DIFF
--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -99,6 +99,7 @@ public:
    */
   BufferCore(ros::Duration cache_time_ = ros::Duration(DEFAULT_CACHE_TIME));
   BufferCore(BufferCore&&) = default;
+  BufferCore& operator=(BufferCore&&) = default;
   virtual ~BufferCore(void);
 
   /** \brief Clear all data */

--- a/tf2/include/tf2/buffer_core.h
+++ b/tf2/include/tf2/buffer_core.h
@@ -98,6 +98,7 @@ public:
    *
    */
   BufferCore(ros::Duration cache_time_ = ros::Duration(DEFAULT_CACHE_TIME));
+  BufferCore(BufferCore&&) = default;
   virtual ~BufferCore(void);
 
   /** \brief Clear all data */

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -62,6 +62,7 @@ namespace tf2_ros
      */
     Buffer(ros::Duration cache_time = ros::Duration(BufferCore::DEFAULT_CACHE_TIME), bool debug = false);
     Buffer(Buffer&&) = default;
+    Buffer& operator=(Buffer&&) = default;
 
     /** \brief Get the transform between two frames by frame ID.
      * \param target_frame The frame to which data should be transformed

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -61,6 +61,7 @@ namespace tf2_ros
      * @return 
      */
     Buffer(ros::Duration cache_time = ros::Duration(BufferCore::DEFAULT_CACHE_TIME), bool debug = false);
+    Buffer(Buffer&&) = default;
 
     /** \brief Get the transform between two frames by frame ID.
      * \param target_frame The frame to which data should be transformed


### PR DESCRIPTION
Currently, the class `BufferCor`e is not movable because the existence of the destructor suppresses the compiler from auto-generating a move constructor for `BufferCore`.  Since `BufferCore` has a mutex as a member variable, it is already non-copyable.   This makes class `BufferCore` and class `Buffer` non-copyable and non-movable. This doesn't seem right.