### PR TITLE
Mitigate flakey test in tf2_ros

### DIFF
--- a/tf2_ros/test/time_reset_test.cpp
+++ b/tf2_ros/test/time_reset_test.cpp
@@ -41,7 +41,7 @@ void spin_for_a_second()
   ros::spinOnce();
   for (uint8_t i = 0; i < 10; ++i)
   {
-    std::this_thread::sleep_for(std::chrono::microseconds(100));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     ros::spinOnce();
   }
 }


### PR DESCRIPTION
`transform_listener_backwards_reset` fails almost 100% on my AMD EPYC
environment. Sleep by `spin_for_a_second()` seems to be too small and
slept only a millisecond.
Fix it to a second to match with the function name.
This makes the test possible to pass on EPYC environment.