### PR TITLE
New approach for the tf2::toMsg() hassle

### DIFF
--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -110,9 +110,81 @@ TEST(tf2Convert, ConvertTf2Quaternion)
   EXPECT_EQ(tq.z(), eq.z());
 }
 
+TEST(tf2Convert, PointVectorDefaultMessagetype)
+{
+  // Verify the return type of `toMsg()`
+  // as it can return a Vector3 or a Point for certain datatypes
+  {
+    // Bullet
+    const tf2::Stamped<btVector3> b1{btVector3{1.0, 3.0, 4.0}, ros::Time(), "my_frame" };
+    const geometry_msgs::PointStamped msg = tf2::toMsg(b1);
+
+    EXPECT_EQ(msg.point.x, 1.0);
+    EXPECT_EQ(msg.point.y, 3.0);
+    EXPECT_EQ(msg.point.z, 4.0);
+    EXPECT_EQ(msg.header.frame_id, b1.frame_id_);
+    EXPECT_EQ(msg.header.stamp, b1.stamp_);
+  }
+  {
+    // Eigen
+    const Eigen::Vector3d e1{2.0, 4.0, 5.0};
+    const geometry_msgs::Point msg = tf2::toMsg(e1);
+
+    EXPECT_EQ(msg.x, 2.0);
+    EXPECT_EQ(msg.y, 4.0);
+    EXPECT_EQ(msg.z, 5.0);
+  }
+  {
+    // tf2
+    const tf2::Vector3 t1{2.0, 4.0, 5.0};
+    const geometry_msgs::Vector3 msg = tf2::toMsg(t1);
+
+    EXPECT_EQ(msg.x, 2.0);
+    EXPECT_EQ(msg.y, 4.0);
+    EXPECT_EQ(msg.z, 5.0);
+  }
+  {
+    // KDL
+    const tf2::Stamped<KDL::Vector> k1{KDL::Vector{1.0, 3.0, 4.0}, ros::Time(), "my_frame"};
+    const geometry_msgs::PointStamped msg = tf2::toMsg(k1);
+
+    EXPECT_EQ(msg.point.x, 1.0);
+    EXPECT_EQ(msg.point.y, 3.0);
+    EXPECT_EQ(msg.point.z, 4.0);
+    EXPECT_EQ(msg.header.frame_id, k1.frame_id_);
+    EXPECT_EQ(msg.header.stamp, k1.stamp_);
+  }
+}
+
+TEST(tf2Convert, PointVectorOtherMessagetype)
+{
+  {
+    const tf2::Vector3 t1{2.0, 4.0, 5.0};
+    geometry_msgs::Point msg;
+    const geometry_msgs::Point& msg2 = tf2::toMsg(t1, msg);
+
+    // returned reference is second argument
+    EXPECT_EQ(&msg2, &msg);
+    EXPECT_EQ(msg.x, 2.0);
+    EXPECT_EQ(msg.y, 4.0);
+    EXPECT_EQ(msg.z, 5.0);
+  }
+  {
+    // Eigen
+    const Eigen::Vector3d e1{2.0, 4.0, 5.0};
+    geometry_msgs::Vector3 msg;
+    const geometry_msgs::Vector3& msg2 = tf2::toMsg(e1, msg);
+
+    // returned reference is second argument
+    EXPECT_EQ(&msg2, &msg);
+    EXPECT_EQ(msg.x, 2.0);
+    EXPECT_EQ(msg.y, 4.0);
+    EXPECT_EQ(msg.z, 5.0);
+  }
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -40,11 +40,40 @@ namespace tf2
 {
 namespace impl
 {
+/**
+ * \brief Mapping between Datatypes (like \c Vector3d ) and their default ROS Message types.
+ *
+ * This struct should be specialized for each non-Message datatypes,
+ * and it should contain an alias of the Message class with the name \c type .
+ * This alias will be used to deduce the return value of tf2::toMsg().
+ *
+ * \tparam Datatype Non-Message datatype like \c Vector3d
+ */
 template <class Datatype, class = void>
 struct defaultMessage
 {
   // using type = ...;
 };
+
+/**
+ * \brief Conversion details between a Message and a non-Message datatype.
+ * \tparam Datatype Non-Message datatype like \c Vector3d
+ * \tparam Message  The ROS Message class
+ *
+ * The specializations of this struct should contain two static methods,
+ * which convert a ROS Message into the requested datatype and vice versa.
+ * They should have the following signature:
+ * \code
+ * template<>
+ * struct defautMessage<Datatype, Message>
+ * {
+ *   static void toMsg(const Datatype&, Message&);
+ *   static void fromMsg(const Message&, Datatype&);
+ * }:
+ * \endcode
+ * Note that the conversion between tf2::Stamped\<Datatype\> and
+ * geometry_msgs::...Stamped is done automatically.
+ */
 template <class Datatype, class Message, class = void>
 struct ImplDetails
 {
@@ -52,8 +81,10 @@ struct ImplDetails
   // void fromMsg(const Message&, Datatype&);
 };
 
+// Forward declaration for the extraction of timestamps and frame IDs
 template <typename T, int = 0>
 struct DefaultStampedImpl;
+// Forward declaration for the tf2::convert() implementation
 template <bool, bool>
 class Converter;
 
@@ -73,8 +104,13 @@ void doTransform(const T& data_in, T& data_out, const geometry_msgs::TransformSt
 
 /**\brief Get the timestamp from data
  * \param t The data input.
+ * \tparam T The type of the data input.
  * \return The timestamp associated with the data. The lifetime of the returned
  * reference is bound to the lifetime of the argument.
+ *
+ * Library developers need to check whether the default implementation
+ * is sufficient, extend the default implementation
+ * or provide a specialization of this function.
  */
 template <class T>
 inline
@@ -85,8 +121,13 @@ const ros::Time& getTimestamp(const T& t)
 
 /**\brief Get the frame_id from data
  * \param t The data input.
+ * \tparam T The type of the data input.
  * \return The frame_id associated with the data. The lifetime of the returned
  * reference is bound to the lifetime of the argument.
+ *
+ * Library developers need to check whether the default implementation
+ * is sufficient, extend the default implementation
+ * or provide a specialization of this function.
  */
 template <class T>
 inline
@@ -95,10 +136,14 @@ const std::string& getFrameId(const T& t)
   return impl::DefaultStampedImpl<T>::getFrameId(t);
 }
 
-/** Function that converts from one type to a ROS message type. It has to be
- * implemented by each data type in tf2_* (except ROS messages) as it is
- * used in the "convert" function.
+/**
+ * \brief Function that converts from one type to a ROS message type.
+ *
+ * The implementation of this function should be done in the tf2_* packages
+ * for each datatypes. Preferably in a specialization of the impl::ImplDetails struct.
  * \param a an object of whatever type
+ * \tparam A Non-message Datatype
+ * \tparam B ROS message Datatype. The default value will be taken from impl::defaultMessage\<A\>::type.
  * \return the conversion as a ROS message
  */
 template <typename A, typename B = typename impl::defaultMessage<A>::type>
@@ -109,6 +154,18 @@ inline B toMsg(const A& a)
   return b;
 }
 
+
+/**
+ * \brief Function that converts from one type to a ROS message type.
+ *
+ * The implementation of this function should be done in the tf2_* packages
+ * for each datatypes. Preferably in a specialization of the impl::ImplDetails struct.
+ * \param a an object of whatever type
+ * \param b ROS message
+ * \tparam A Non-message Datatype
+ * \tparam B Type of the ROS Message
+ * \return Reference to the parameter b
+ */
 template <typename A, typename B>
 inline B& toMsg(const A& a, B& b)
 {
@@ -116,11 +173,15 @@ inline B& toMsg(const A& a, B& b)
   return b;
 }
 
-/** Function that converts from a ROS message type to another type. It has to be
- * implemented by each data type in tf2_* (except ROS messages) as it is used
- * in the "convert" function.
+/**
+ * \brief Function that converts from a ROS message type to another type.
+ *
+ * The implementation of this function should be done in the tf2_* packages
+ * for each datatypes. Preferably in a specialization of the impl::ImplDetails struct.
  * \param a a ROS message to convert from
  * \param b the object to convert to
+ * \tparam A ROS message type
+ * \tparam B Arbitrary type
  */
 template <typename A, typename B>
 inline void fromMsg(const A& a, B& b)
@@ -128,24 +189,26 @@ inline void fromMsg(const A& a, B& b)
   impl::ImplDetails<B, A>::fromMsg(a, b);
 }
 
-/** Function that converts any type to any type (messages or not).
+/**
+ * \brief Function that converts any type to any type (messages or not).
+ *
  * Matching toMsg and from Msg conversion functions need to exist.
  * If they don't exist or do not apply (for example, if your two
  * classes are ROS messages), just write a specialization of the function.
  * \param a an object to convert from
  * \param b the object to convert to
+ * \tparam A Type of the object to convert from
+ * \tparam B Type of the object to convert to
  */
 template <class A, class B>
 inline void convert(const A& a, B& b)
 {
-  // printf("In double type convert\n");
   impl::Converter<ros::message_traits::IsMessage<A>::value, ros::message_traits::IsMessage<B>::value>::convert(a, b);
 }
 
 template <class A>
 inline void convert(const A& a1, A& a2)
 {
-  // printf("In single type convert\n");
   if (&a1 != &a2)
     a2 = a1;
 }

--- a/tf2/include/tf2/impl/convert.h
+++ b/tf2/include/tf2/impl/convert.h
@@ -35,6 +35,35 @@ namespace tf2
 namespace impl
 {
 
+/**
+ * \brief Mapping of unstamped Messages for stamped Messages
+ *
+ * This struct contains utility methods to access the data member of a stamped ROS message
+ * and an alias (named \c unstampedType ) of the unstamped message type.
+ * It is needed for the conversion of stamped datatypes,
+ * so that only the conversions of unstamped datatypes has do be implemented.
+ * For example, a \c geometry_msgs::Vector3Stamped has two members,
+ * the \c header (which contains a timestamp and a frame ID) and the \c vector itself.
+ * For this class, the specialization should look like
+ * \code
+ * template<>
+ * struct stampedMessageTraits<geometry_msgs::Vector3Stamped>
+ * {
+ *  using unstampedType = geometry_msgs::Vector3;
+ *  static geometry_msgs::Vector3& accessMessage(geometry_msgs::Vector3Stamped& vs)
+ *  {
+ *     return vs.vector;
+ *  }
+ *  static geometry_msgs::Vector3 getMessage(const geometry_msgs::Vector3Stamped& vs)
+ *  {
+ *     return vs.vector;
+ *  }
+ * };
+ * \endcode
+ * The both almost identical methods are required to keep const-correctness.
+ *
+ * \tparam StampedMessage The datatype of the ros message
+ */
 template <class StampedMessage>
 struct stampedMessageTraits
 {
@@ -43,11 +72,37 @@ struct stampedMessageTraits
   // static unstampedType getMessage(StampedMsg const&);
 };
 
+/**
+ * \brief Mapping of stamped Messages for unstamped Messages
+ *
+ * This struct is needed for the deduction of the return type of
+ * tf2::convert() for tf2::Stamped\<\> datatypes.
+ * Its specializations should contain an alias (named \c stampedType )
+ * of the stamped type.
+ * Example:
+ * \code
+ * template<>
+ * struct unstampedMessageTraits<geometry_msgs::Vector3>
+ * {
+ *    using stampedType = geometry_msgs::Vector3Stamped;
+ * };
+ * \endcode
+ *
+ * \tparam UnstampedMessage Type of the ROS message which is not stamped
+ */
 template <class UnstampedMessage>
 struct unstampedMessageTraits
 {
   // using stampedType = ...;
 };
+
+/**
+ * \brief Partial specialization of impl::defaultMessage for stamped types
+ *
+ * The deduction of the default ROS message type of a tf2::Stamped\<T\> type is
+ * based on the default ROS message type of \c T .
+ * \tparam T The unstamped datatype (not a ROS message)
+ */
 
 template <class T>
 struct defaultMessage<tf2::Stamped<T>>
@@ -55,12 +110,21 @@ struct defaultMessage<tf2::Stamped<T>>
   using type = typename unstampedMessageTraits<typename defaultMessage<T>::type>::stampedType;
 };
 
-
+/**
+ * \brief Partial specialization of impl::ImplDetails for stamped types
+ *
+ * This partial specialization provides the conversion implementation ( \c toMsg() and \c fromMsg() )
+ * between stamped types ( non-message types of tf2::Stamped\<T\> and ROS message datatypes with a \c header member).
+ * The timestamp and the frame ID are preserved during the conversion.
+ * The implementation of tf2::toMsg() and tf2::fromMsg() for the unstamped types are required,
+ * as well as a specialization of stampedMessageTraits.
+ * \tparam Datatype Unstamped non-message type
+ * \tparam StampedMessage Stamped ROS message type
+ */
 template <class Datatype, class StampedMessage>
 struct ImplDetails<tf2::Stamped<Datatype>, StampedMessage>
 {
   using traits = stampedMessageTraits<StampedMessage>;
-  using unstampedMessage = typename traits::unstampedType;
 
   static void toMsg(const tf2::Stamped<Datatype>& s, StampedMessage& msg)
   {
@@ -120,27 +184,61 @@ inline void Converter<false, false>::convert(const A& a, B& b)
 template <typename T>
 using void_t = void;
 
+/**
+ * \brief Default implementation for extracting timestamps and frame IDs.
+ *
+ * Both static member functions are for stamped ROS messages.
+ * They are SFINAE'd out if T is not a stamped ROS message.
+ *
+ * \tparam T Arbitrary datatype
+ */
 template <typename T, int>
 struct DefaultStampedImpl
 {
+  /**\brief Get the timestamp from data
+   * \param t The data input.
+   * \return The timestamp associated with the data. The lifetime of the returned
+   * reference is bound to the lifetime of the argument.
+   *
+   * The second parameter is needed to hide the default implementation if T is not a stamped ROS message.
+   */
   static const ros::Time& getTimestamp(const T& t, void_t<typename stampedMessageTraits<T>::unstampedType>* = nullptr)
   {
     return t.header.stamp;
   }
-
+  /**\brief Get the frame_id from data
+   * \param t The data input.
+   * \return The frame_id associated with the data. The lifetime of the returned
+   * reference is bound to the lifetime of the argument.
+   *
+   * The second parameter is needed to hide the default implementation if T is not a stamped ROS message.
+   */
   static const std::string& getFrameId(const T& t, void_t<typename stampedMessageTraits<T>::unstampedType>* = nullptr)
   {
     return t.header.frame_id;
   }
 };
 
+/**
+ * \brief Partial specialization of DefaultStampedImpl for tf2::Stamped\<\> types
+ */
 template <typename T>
 struct DefaultStampedImpl<tf2::Stamped<T>>
 {
+  /**\brief Get the timestamp from data
+   * \param t The data input.
+   * \return The timestamp associated with the data. The lifetime of the returned
+   * reference is bound to the lifetime of the argument.
+   */
   static const ros::Time& getTimestamp(const tf2::Stamped<T>& t)
   {
     return t.stamp_;
   }
+  /**  brief Get the frame_id from data
+   * \param t The data input.
+   * \return The frame_id associated with the data. The lifetime of the returned
+   * reference is bound to the lifetime of the argument.
+   */
   static const std::string& getFrameId(const tf2::Stamped<T>& t)
   {
     return t.frame_id_;

--- a/tf2/include/tf2/impl/stamped_traits.h
+++ b/tf2/include/tf2/impl/stamped_traits.h
@@ -136,6 +136,9 @@ struct unstampedMessageTraits<geometry_msgs::Vector3_<Alloc>>
 template <class StampedMessage>
 struct stampedMessageTraits;
 
+// we use partial specializations (with the allocator as template parameter)
+// to avoid including all the message definitons
+
 template <typename Alloc>
 struct stampedMessageTraits<geometry_msgs::PointStamped_<Alloc>>
 {

--- a/tf2/include/tf2/impl/stamped_traits.h
+++ b/tf2/include/tf2/impl/stamped_traits.h
@@ -1,0 +1,272 @@
+
+/*
+ * Copyright (c) 2013, Open Source Robotics Foundation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TF2_IMPL_STAMPED_TRAITS_H_
+#define TF2_IMPL_STAMPED_TRAITS_H_
+
+// forward declarations
+namespace geometry_msgs
+{
+template <typename Alloc>
+class Point_;
+template <typename Alloc>
+class Vector_;
+template <typename Alloc>
+class Quaternion_;
+template <typename Alloc>
+class Pose_;
+template <typename Alloc>
+class Twist_;
+template <typename Alloc>
+class PoseWithCovariance_;
+template <typename Alloc>
+class Wrench_;
+template <typename Alloc>
+class PointStamped_;
+template <typename Alloc>
+class VectorStamped_;
+template <typename Alloc>
+class QuaternionStamped_;
+template <typename Alloc>
+class PoseStamped_;
+template <typename Alloc>
+class TwistStamped_;
+template <typename Alloc>
+class PoseWithCovarianceStamped_;
+template <typename Alloc>
+class WrenchStamped_;
+template <typename Alloc>
+class TransformStamped_;
+template <typename Alloc>
+class Transform_;
+template <typename Alloc>
+class Vector3_;
+template <typename Alloc>
+class Vector3Stamped_;
+}  // namespace geometry_msgs
+
+namespace tf2
+{
+namespace impl
+{
+template <class UnstampedMessage>
+struct unstampedMessageTraits;
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Point_<Alloc>>
+{
+  using stampedType = geometry_msgs::PointStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Vector_<Alloc>>
+{
+  using stampedType = geometry_msgs::VectorStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Quaternion_<Alloc>>
+{
+  using stampedType = geometry_msgs::QuaternionStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Pose_<Alloc>>
+{
+  using stampedType = geometry_msgs::PoseStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Twist_<Alloc>>
+{
+  using stampedType = geometry_msgs::TwistStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::PoseWithCovariance_<Alloc>>
+{
+  using stampedType = geometry_msgs::PoseWithCovarianceStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Wrench_<Alloc>>
+{
+  using stampedType = geometry_msgs::WrenchStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Transform_<Alloc>>
+{
+  using stampedType = geometry_msgs::TransformStamped_<Alloc>;
+};
+
+template <typename Alloc>
+struct unstampedMessageTraits<geometry_msgs::Vector3_<Alloc>>
+{
+  using stampedType = geometry_msgs::Vector3Stamped_<Alloc>;
+};
+
+template <class StampedMessage>
+struct stampedMessageTraits;
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::PointStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Point_<Alloc>;
+  static geometry_msgs::Point_<Alloc>& accessMessage(geometry_msgs::PointStamped_<Alloc>& smsg)
+  {
+    return smsg.point;
+  }
+  static geometry_msgs::Point_<Alloc> getMessage(geometry_msgs::PointStamped_<Alloc> const& smsg)
+  {
+    return smsg.point;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::VectorStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Vector_<Alloc>;
+  static geometry_msgs::Vector_<Alloc>& accessMessage(geometry_msgs::VectorStamped_<Alloc>& smsg)
+  {
+    return smsg.vector;
+  }
+  static geometry_msgs::Vector_<Alloc> getMessage(geometry_msgs::VectorStamped_<Alloc> const& smsg)
+  {
+    return smsg.vector;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::QuaternionStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Quaternion_<Alloc>;
+  static geometry_msgs::Quaternion_<Alloc>& accessMessage(geometry_msgs::QuaternionStamped_<Alloc>& smsg)
+  {
+    return smsg.quaternion;
+  }
+  static geometry_msgs::Quaternion_<Alloc> getMessage(geometry_msgs::QuaternionStamped_<Alloc> const& smsg)
+  {
+    return smsg.quaternion;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::PoseStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Pose_<Alloc>;
+  static geometry_msgs::Pose_<Alloc>& accessMessage(geometry_msgs::PoseStamped_<Alloc>& smsg)
+  {
+    return smsg.pose;
+  }
+  static geometry_msgs::Pose_<Alloc> getMessage(geometry_msgs::PoseStamped_<Alloc> const& smsg)
+  {
+    return smsg.pose;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::TwistStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Twist_<Alloc>;
+  static geometry_msgs::Twist_<Alloc>& accessMessage(geometry_msgs::TwistStamped_<Alloc>& smsg)
+  {
+    return smsg.twist;
+  }
+  static geometry_msgs::Twist_<Alloc> getMessage(geometry_msgs::TwistStamped_<Alloc> const& smsg)
+  {
+    return smsg.twist;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::PoseWithCovarianceStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::PoseWithCovariance_<Alloc>;
+  static geometry_msgs::PoseWithCovariance_<Alloc>&
+  accessMessage(geometry_msgs::PoseWithCovarianceStamped_<Alloc>& smsg)
+  {
+    return smsg.pose;
+  }
+  static geometry_msgs::PoseWithCovariance_<Alloc>
+  getMessage(geometry_msgs::PoseWithCovarianceStamped_<Alloc> const& smsg)
+  {
+    return smsg.pose;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::WrenchStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Wrench_<Alloc>;
+  static geometry_msgs::Wrench_<Alloc>& accessMessage(geometry_msgs::WrenchStamped_<Alloc>& smsg)
+  {
+    return smsg.wrench;
+  }
+  static geometry_msgs::Wrench_<Alloc> getMessage(geometry_msgs::WrenchStamped_<Alloc> const& smsg)
+  {
+    return smsg.wrench;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::TransformStamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Transform_<Alloc>;
+  static geometry_msgs::Transform_<Alloc>& accessMessage(geometry_msgs::TransformStamped_<Alloc>& smsg)
+  {
+    return smsg.transform;
+  }
+
+  static geometry_msgs::Transform_<Alloc> getMessage(geometry_msgs::TransformStamped_<Alloc> const& smsg)
+  {
+    return smsg.transform;
+  }
+};
+
+template <typename Alloc>
+struct stampedMessageTraits<geometry_msgs::Vector3Stamped_<Alloc>>
+{
+  using unstampedType = geometry_msgs::Vector3_<Alloc>;
+  static geometry_msgs::Vector3_<Alloc>& accessMessage(geometry_msgs::Vector3Stamped_<Alloc>& smsg)
+  {
+    return smsg.vector;
+  }
+
+  static geometry_msgs::Vector3_<Alloc> getMessage(geometry_msgs::Vector3Stamped_<Alloc> const& smsg)
+  {
+    return smsg.vector;
+  }
+};
+
+}  // namespace impl
+}  // namespace tf2
+
+#endif  // TF2_IMPL_STAMPED_TRAITS_H_

--- a/tf2_bullet/include/tf2_bullet/tf2_bullet.h
+++ b/tf2_bullet/include/tf2_bullet/tf2_bullet.h
@@ -65,38 +65,42 @@ inline
     t_out = tf2::Stamped<btVector3>(transformToBullet(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
 
-/** \brief Convert a stamped Bullet Vector3 type to a PointStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h
- * \param in The timestamped Bullet btVector3 to convert.
- * \return The vector converted to a PointStamped message.
- */
-inline
-geometry_msgs::PointStamped toMsg(const tf2::Stamped<btVector3>& in)
+namespace impl
 {
-  geometry_msgs::PointStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.point.x = in[0];
-  msg.point.y = in[1];
-  msg.point.z = in[2];
-  return msg;
-}
-
-/** \brief Convert a PointStamped message type to a stamped Bullet-specific Vector3 type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
- * \param msg The PointStamped message to convert.
- * \param out The point converted to a timestamped Bullet Vector3.
- */
-inline
-void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<btVector3>& out)
+template <>
+struct defaultMessage<btVector3>
 {
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out[0] = msg.point.x;
-  out[1] = msg.point.y;
-  out[2] = msg.point.z;
-}
+  using type = geometry_msgs::Point;
+};
 
+template <>
+struct ImplDetails<btVector3, geometry_msgs::Point>
+{
+  /** \brief Convert a stamped Bullet Vector3 type to a PointStamped message.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h
+   * \param in The timestamped Bullet btVector3 to convert.
+   * \return The vector converted to a PointStamped message.
+   */
+  static void toMsg(const btVector3& in, geometry_msgs::Point& msg)
+  {
+    msg.x = in[0];
+    msg.y = in[1];
+    msg.z = in[2];
+  }
+
+  /** \brief Convert a PointStamped message type to a stamped Bullet-specific Vector3 type.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h
+   * \param msg The PointStamped message to convert.
+   * \param out The point converted to a timestamped Bullet Vector3.
+   */
+  static void fromMsg(const geometry_msgs::Point& msg, btVector3& out)
+  {
+    out[0] = msg.x;
+    out[1] = msg.y;
+    out[2] = msg.z;
+  }
+};
+}  // namespace impl
 
 /** \brief Apply a geometry_msgs TransformStamped to a Bullet-specific Transform data type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -68,648 +68,180 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
 		      KDL::Vector(t.transform.translation.x, t.transform.translation.y, t.transform.translation.z));
   }
 
-
+namespace impl
+{
 /*************/
 /** Vector3 **/
 /*************/
 
-/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Vector3 object.
- * \return The Vector3 converted to a geometry_msgs message type.
- */
-inline
-geometry_msgs::Vector3 toMsg(const tf2::Vector3& in)
+template <typename Msg>
+struct tf2VectorImplDetails
 {
-  geometry_msgs::Vector3 out;
-  out.x = in.getX();
-  out.y = in.getY();
-  out.z = in.getZ();
-  return out;
-}
+  /** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in A tf2 Vector3 object.
+   * \return The Vector3 converted to a geometry_msgs message type.
+   */
+  static void toMsg(const tf2::Vector3& in, Msg& out)
+  {
+    out.x = in.getX();
+    out.y = in.getY();
+    out.z = in.getZ();
+  }
 
-/** \brief Convert a Vector3 message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param in A Vector3 message type.
- * \param out The Vector3 converted to a tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::Vector3& in, tf2::Vector3& out)
-{
-  out = tf2::Vector3(in.x, in.y, in.z);
-}
+  /** \brief Convert a Vector3 message to its equivalent tf2 representation.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+   * \param in A Vector3 message type.
+   * \param out The Vector3 converted to a tf2 type.
+   */
+  static void fromMsg(const Msg& in, tf2::Vector3& out)
+  {
+    out = tf2::Vector3(in.x, in.y, in.z);
+  }
+};
 
-
-/********************/
-/** Vector3Stamped **/
-/********************/
-
-/** \brief Extract a timestamp from the header of a Vector message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t VectorStamped message to extract the timestamp from.
- * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the lifetime of the argument.
- */
 template <>
-inline
-  const ros::Time& getTimestamp(const geometry_msgs::Vector3Stamped& t) {return t.header.stamp;}
+struct ImplDetails<tf2::Vector3, geometry_msgs::Vector3> : tf2VectorImplDetails<geometry_msgs::Vector3>
+{
+};
 
-/** \brief Extract a frame ID from the header of a Vector message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t VectorStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the lifetime of the argument.
- */
 template <>
-inline
-  const std::string& getFrameId(const geometry_msgs::Vector3Stamped& t) {return t.header.frame_id;}
-
-
-/** \brief Trivial "conversion" function for Vector3 message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A Vector3Stamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::Vector3Stamped toMsg(const geometry_msgs::Vector3Stamped& in)
+struct ImplDetails<tf2::Vector3, geometry_msgs::Point> : tf2VectorImplDetails<geometry_msgs::Point>
 {
-  return in;
-}
+};
 
-/** \brief Trivial "conversion" function for Vector3 message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A Vector3Stamped message.
- * \param out The input argument.
- */
-inline
-void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Stamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
- * \return The Vector3Stamped converted to a geometry_msgs Vector3Stamped message type.
- */
-inline
-geometry_msgs::Vector3Stamped toMsg(const tf2::Stamped<tf2::Vector3>& in)
-{
-  geometry_msgs::Vector3Stamped out;
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  out.vector.x = in.getX();
-  out.vector.y = in.getY();
-  out.vector.z = in.getZ();
-  return out;
-}
-
-/** \brief Convert a Vector3Stamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A Vector3Stamped message.
- * \param out The Vector3Stamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::Vector3Stamped& msg, tf2::Stamped<tf2::Vector3>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out.setData(tf2::Vector3(msg.vector.x, msg.vector.y, msg.vector.z));
-}
-
-
-/***********/
-/** Point **/
-/***********/
-
-/** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Vector3 object.
- * \return The Vector3 converted to a geometry_msgs message type.
- */
-inline
-geometry_msgs::Point& toMsg(const tf2::Vector3& in, geometry_msgs::Point& out)
-{
-  out.x = in.getX();
-  out.y = in.getY();
-  out.z = in.getZ();
-  return out;
-}
-
-/** \brief Convert a Vector3 message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param in A Vector3 message type.
- * \param out The Vector3 converted to a tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::Point& in, tf2::Vector3& out)
-{
-  out = tf2::Vector3(in.x, in.y, in.z);
-}
-
-
-/******************/
-/** PointStamped **/
-/******************/
-
-/** \brief Extract a timestamp from the header of a Point message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t PointStamped message to extract the timestamp from.
- * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the lifetime of the argument.
- */
 template <>
-inline
-  const ros::Time& getTimestamp(const geometry_msgs::PointStamped& t)  {return t.header.stamp;}
-
-/** \brief Extract a frame ID from the header of a Point message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t PointStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the lifetime of the argument.
- */
-template <>
-inline
-  const std::string& getFrameId(const geometry_msgs::PointStamped& t)  {return t.header.frame_id;}
-
-/** \brief Trivial "conversion" function for Point message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A PointStamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::PointStamped toMsg(const geometry_msgs::PointStamped& in)
+struct defaultMessage<tf2::Vector3>
 {
-  return in;
-}
-
-/** \brief Trivial "conversion" function for Point message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A PointStamped message.
- * \param out The input argument.
- */
-inline
-void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
- * \return The Vector3Stamped converted to a geometry_msgs PointStamped message type.
- */
-inline
-geometry_msgs::PointStamped toMsg(const tf2::Stamped<tf2::Vector3>& in, geometry_msgs::PointStamped & out)
-{
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  out.point.x = in.getX();
-  out.point.y = in.getY();
-  out.point.z = in.getZ();
-  return out;
-}
-
-/** \brief Convert a PointStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A PointStamped message.
- * \param out The PointStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<tf2::Vector3>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out.setData(tf2::Vector3(msg.point.x, msg.point.y, msg.point.z));
-}
-
+  using type = geometry_msgs::Vector3;
+};
 
 /****************/
 /** Quaternion **/
 /****************/
 
-/** \brief Convert a tf2 Quaternion type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Quaternion object.
- * \return The Quaternion converted to a geometry_msgs message type.
- */
-inline
-geometry_msgs::Quaternion toMsg(const tf2::Quaternion& in)
-{
-  geometry_msgs::Quaternion out;
-  out.w = in.getW();
-  out.x = in.getX();
-  out.y = in.getY();
-  out.z = in.getZ();
-  return out;
-}
-
-/** \brief Convert a Quaternion message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param in A Quaternion message type.
- * \param out The Quaternion converted to a tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::Quaternion& in, tf2::Quaternion& out)
-{
-  // w at the end in the constructor
-  out = tf2::Quaternion(in.x, in.y, in.z, in.w);
-}
-
-
-/***********************/
-/** QuaternionStamped **/
-/***********************/
-
-/** \brief Extract a timestamp from the header of a Quaternion message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t QuaternionStamped message to extract the timestamp from.
- * \return The timestamp of the message. The lifetime of the returned reference
- * is bound to the lifetime of the argument.
- */
 template <>
-inline
-const ros::Time& getTimestamp(const geometry_msgs::QuaternionStamped& t)  {return t.header.stamp;}
-
-/** \brief Extract a frame ID from the header of a Quaternion message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t QuaternionStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message. The lifetime of the
- * returned reference is bound to the lifetime of the argument.
- */
-template <>
-inline
-const std::string& getFrameId(const geometry_msgs::QuaternionStamped& t)  {return t.header.frame_id;}
-
-/** \brief Trivial "conversion" function for Quaternion message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A QuaternionStamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::QuaternionStamped toMsg(const geometry_msgs::QuaternionStamped& in)
+struct ImplDetails<tf2::Quaternion, geometry_msgs::Quaternion>
 {
-  return in;
-}
+  /** \brief Convert a tf2 Quaternion type to its equivalent geometry_msgs representation.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in A tf2 Quaternion object.
+   * \return The Quaternion converted to a geometry_msgs message type.
+   */
+  static void toMsg(const tf2::Quaternion& in, geometry_msgs::Quaternion& out)
+  {
+    out.w = in.getW();
+    out.x = in.getX();
+    out.y = in.getY();
+    out.z = in.getZ();
+  }
 
-/** \brief Trivial "conversion" function for Quaternion message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A QuaternionStamped message.
- * \param out The input argument.
- */
-inline
-void fromMsg(const geometry_msgs::QuaternionStamped& msg, geometry_msgs::QuaternionStamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 Quaternion type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Quaternion specialization of the tf2::Stamped template.
- * \return The QuaternionStamped converted to a geometry_msgs QuaternionStamped message type.
- */
-inline
-geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
-{
-  geometry_msgs::QuaternionStamped out;
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  out.quaternion.w = in.getW();
-  out.quaternion.x = in.getX();
-  out.quaternion.y = in.getY();
-  out.quaternion.z = in.getZ();
-  return out;
-}
+  /** \brief Convert a Quaternion message to its equivalent tf2 representation.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+   * \param in A Quaternion message type.
+   * \param out The Quaternion converted to a tf2 type.
+   */
+  static void fromMsg(const geometry_msgs::Quaternion& in, tf2::Quaternion& out)
+  {
+    // w at the end in the constructor
+    out = tf2::Quaternion(in.x, in.y, in.z, in.w);
+  }
+};
 
 template <>
-inline
-ROS_DEPRECATED geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in);
-
-
-//Backwards compatibility remove when forked for Lunar or newer
-template <>
-inline
-geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
+struct defaultMessage<tf2::Quaternion>
 {
-  return toMsg(in);
-}
-
-/** \brief Convert a QuaternionStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param in A QuaternionStamped message type.
- * \param out The QuaternionStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out)
-{
-  out.stamp_ = in.header.stamp;
-  out.frame_id_ = in.header.frame_id;
-  tf2::Quaternion tmp;
-  fromMsg(in.quaternion, tmp);
-  out.setData(tmp);
-}
-
-template<>
-inline
-ROS_DEPRECATED void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out);
-
-//Backwards compatibility remove when forked for Lunar or newer
-template<>
-inline
-void fromMsg(const geometry_msgs::QuaternionStamped& in, tf2::Stamped<tf2::Quaternion>& out)
-{
-    fromMsg(in, out);
-}
+  using type = geometry_msgs::Quaternion;
+};
 
 /**********/
 /** Pose **/
 /**********/
 
-/** \brief Convert a tf2 Transform type to an equivalent geometry_msgs Pose message.
- * \param in A tf2 Transform object.
- * \param out The Transform converted to a geometry_msgs Pose message type.
- */
-inline
-geometry_msgs::Pose& toMsg(const tf2::Transform& in, geometry_msgs::Pose& out)
-{
-  toMsg(in.getOrigin(), out.position);
-  out.orientation = toMsg(in.getRotation());
-  return out;
-}
-
-/** \brief Convert a geometry_msgs Pose message to an equivalent tf2 Transform type.
- * \param in A Pose message.
- * \param out The Pose converted to a tf2 Transform type.
- */
-inline
-void fromMsg(const geometry_msgs::Pose& in, tf2::Transform& out)
-{
-  out.setOrigin(tf2::Vector3(in.position.x, in.position.y, in.position.z));
-  // w at the end in the constructor
-  out.setRotation(tf2::Quaternion(in.orientation.x, in.orientation.y, in.orientation.z, in.orientation.w));
-}
-
-
-
-/*****************/
-/** PoseStamped **/
-/*****************/
-
-/** \brief Extract a timestamp from the header of a Pose message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t PoseStamped message to extract the timestamp from.
- * \return The timestamp of the message.
- */
 template <>
-inline
-  const ros::Time& getTimestamp(const geometry_msgs::PoseStamped& t)  {return t.header.stamp;}
-
-/** \brief Extract a frame ID from the header of a Pose message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t PoseStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
- */
-template <>
-inline
-  const std::string& getFrameId(const geometry_msgs::PoseStamped& t)  {return t.header.frame_id;}
-
-/** \brief Trivial "conversion" function for Pose message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A PoseStamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
+struct ImplDetails<tf2::Transform, geometry_msgs::Pose>
 {
-  return in;
-}
+  /** \brief Convert a tf2 Transform type to an equivalent geometry_msgs Pose message.
+   * \param in A tf2 Transform object.
+   * \param out The Transform converted to a geometry_msgs Pose message type.
+   */
+  static void toMsg(const tf2::Transform& in, geometry_msgs::Pose& out)
+  {
+    tf2::toMsg(in.getOrigin(), out.position);
+    tf2::toMsg(in.getRotation(), out.orientation);
+  }
 
-/** \brief Trivial "conversion" function for Pose message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A PoseStamped message.
- * \param out The input argument.
- */
-inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 Pose type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Pose specialization of the tf2::Stamped template.
- * \return The PoseStamped converted to a geometry_msgs PoseStamped message type.
- */
-inline
-geometry_msgs::PoseStamped toMsg(const tf2::Stamped<tf2::Transform>& in, geometry_msgs::PoseStamped & out)
-{
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  toMsg(in.getOrigin(), out.pose.position);
-  out.pose.orientation = toMsg(in.getRotation());
-  return out;
-}
-
-/** \brief Convert a PoseStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A PoseStamped message.
- * \param out The PoseStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<tf2::Transform>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  tf2::Transform tmp;
-  fromMsg(msg.pose, tmp);
-  out.setData(tmp);
-}
+  /** \brief Convert a geometry_msgs Pose message to an equivalent tf2 Transform type.
+   * \param in A Pose message.
+   * \param out The Pose converted to a tf2 Transform type.
+   */
+  static void fromMsg(const geometry_msgs::Pose& in, tf2::Transform& out)
+  {
+    out.setOrigin(tf2::Vector3(in.position.x, in.position.y, in.position.z));
+    // w at the end in the constructor
+    out.setRotation(tf2::Quaternion(in.orientation.x, in.orientation.y, in.orientation.z, in.orientation.w));
+  }
+};
 
 /*******************************/
 /** PoseWithCovarianceStamped **/
 /*******************************/
 
-/** \brief Extract a timestamp from the header of a PoseWithCovarianceStamped message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t PoseWithCovarianceStamped message to extract the timestamp from.
- * \return The timestamp of the message.
- */
 template <>
-inline
-  const ros::Time& getTimestamp(const geometry_msgs::PoseWithCovarianceStamped& t)  {return t.header.stamp;}
-
-/** \brief Extract a frame ID from the header of a PoseWithCovarianceStamped message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t PoseWithCovarianceStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
- */
-template <>
-inline
-  const std::string& getFrameId(const geometry_msgs::PoseWithCovarianceStamped& t)  {return t.header.frame_id;}
-
-/** \brief Trivial "conversion" function for PoseWithCovarianceStamped message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A PoseWithCovarianceStamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::PoseWithCovarianceStamped toMsg(const geometry_msgs::PoseWithCovarianceStamped& in)
+struct ImplDetails<tf2::Transform, geometry_msgs::PoseWithCovariance>
 {
-  return in;
-}
-
-/** \brief Trivial "conversion" function for PoseWithCovarianceStamped message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A PoseWithCovarianceStamped message.
- * \param out The input argument.
- */
-inline
-void fromMsg(const geometry_msgs::PoseWithCovarianceStamped& msg, geometry_msgs::PoseWithCovarianceStamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 PoseWithCovarianceStamped type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Pose specialization of the tf2::Stamped template.
- * \return The PoseWithCovarianceStamped converted to a geometry_msgs PoseWithCovarianceStamped message type.
- */
-inline
-geometry_msgs::PoseWithCovarianceStamped toMsg(const tf2::Stamped<tf2::Transform>& in, geometry_msgs::PoseWithCovarianceStamped & out)
-{
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  toMsg(in.getOrigin(), out.pose.pose.position);
-  out.pose.pose.orientation = toMsg(in.getRotation());
-  return out;
-}
-
-/** \brief Convert a PoseWithCovarianceStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A PoseWithCovarianceStamped message.
- * \param out The PoseWithCovarianceStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::PoseWithCovarianceStamped& msg, tf2::Stamped<tf2::Transform>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  tf2::Transform tmp;
-  fromMsg(msg.pose, tmp);
-  out.setData(tmp);
-}
+  /** \brief Convert a PoseWithCovarianceStamped message to its equivalent tf2 representation.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+   * \param msg A PoseWithCovarianceStamped message.
+   * \param out The PoseWithCovarianceStamped converted to the equivalent tf2 type.
+   */
+  static void fromMsg(const geometry_msgs::PoseWithCovariance& msg, tf2::Transform& out)
+  {
+    tf2::fromMsg<>(msg.pose, out);
+  }
+};
 
 /***************/
 /** Transform **/
 /***************/
 
-/** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A tf2 Transform object.
- * \return The Transform converted to a geometry_msgs message type.
- */
-inline
-geometry_msgs::Transform toMsg(const tf2::Transform& in)
-{
-  geometry_msgs::Transform out;
-  out.translation = toMsg(in.getOrigin());
-  out.rotation = toMsg(in.getRotation());
-  return out;
-}
-
-/** \brief Convert a Transform message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A Transform message type.
- * \param out The Transform converted to a tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::Transform& in, tf2::Transform& out)
-{
-  tf2::Vector3 v;
-  fromMsg(in.translation, v);
-  out.setOrigin(v);
-  // w at the end in the constructor
-  tf2::Quaternion q;
-  fromMsg(in.rotation, q);
-  out.setRotation(q);
-}
-
-
-/**********************/
-/** TransformStamped **/
-/**********************/
-
-/** \brief Extract a timestamp from the header of a Transform message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
- * \param t TransformStamped message to extract the timestamp from.
- * \return The timestamp of the message.
- */
 template <>
-inline
-const ros::Time& getTimestamp(const geometry_msgs::TransformStamped& t)  {return t.header.stamp;}
+struct ImplDetails<tf2::Transform, geometry_msgs::Transform>
+{
+  /** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in A tf2 Transform object.
+   * \return The Transform converted to a geometry_msgs message type.
+   */
+  static void toMsg(const tf2::Transform& in, geometry_msgs::Transform& out)
+  {
+    tf2::toMsg(in.getOrigin(), out.translation);
+    tf2::toMsg(in.getRotation(), out.rotation);
+  }
 
-/** \brief Extract a frame ID from the header of a Transform message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
- * \param t TransformStamped message to extract the frame ID from.
- * \return A string containing the frame ID of the message.
- */
+  /** \brief Convert a Transform message to its equivalent tf2 representation.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in A Transform message type.
+   * \param out The Transform converted to a tf2 type.
+   */
+  static void fromMsg(const geometry_msgs::Transform& in, tf2::Transform& out)
+  {
+    tf2::Vector3 v;
+    tf2::fromMsg(in.translation, v);
+    out.setOrigin(v);
+    // w at the end in the constructor
+    tf2::Quaternion q;
+    tf2::fromMsg(in.rotation, q);
+    out.setRotation(q);
+  }
+};
+
 template <>
-inline
-const std::string& getFrameId(const geometry_msgs::TransformStamped& t)  {return t.header.frame_id;}
-
-/** \brief Trivial "conversion" function for Transform message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in A TransformStamped message.
- * \return The input argument.
- */
-inline
-geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
+struct defaultMessage<tf2::Transform>
 {
-  return in;
-}
-
-/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A TransformStamped message type.
- * \param out The TransformStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)
-{
-  out = msg;
-}
-
-/** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.
- * \return The tf2::Stamped<tf2::Transform> converted to a geometry_msgs TransformStamped message type.
- */
-inline
-geometry_msgs::TransformStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
-{
-  geometry_msgs::TransformStamped out;
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  out.transform.translation = toMsg(in.getOrigin());
-  out.transform.rotation = toMsg(in.getRotation());
-  return out;
-}
-
-
-/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg A TransformStamped message.
- * \param out The TransformStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::TransformStamped& msg, tf2::Stamped<tf2::Transform>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  tf2::Transform tmp;
-  fromMsg(msg.transform, tmp);
-  out.setData(tmp);
-}
+  using type = geometry_msgs::Transform;
+};
+}  // namespace impl
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Point type.
  * This function is a specialization of the doTransform template defined in tf2/convert.h.
@@ -721,12 +253,12 @@ template <>
 inline
   void doTransform(const geometry_msgs::Point& t_in, geometry_msgs::Point& t_out, const geometry_msgs::TransformStamped& transform)
   {
-    tf2::Transform t;
-    fromMsg(transform.transform, t);
-    tf2::Vector3 v_in;
-    fromMsg(t_in, v_in);
-    tf2::Vector3 v_out = t * v_in;
-    toMsg(v_out, t_out);
+  tf2::Transform t;
+  tf2::fromMsg<>(transform.transform, t);
+  tf2::Vector3 v_in;
+  tf2::fromMsg<>(t_in, v_in);
+  tf2::Vector3 v_out = t * v_in;
+  tf2::toMsg<>(v_out, t_out);
   }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Point type.
@@ -755,11 +287,11 @@ inline
 void doTransform(const geometry_msgs::Quaternion& t_in, geometry_msgs::Quaternion& t_out, const geometry_msgs::TransformStamped& transform)
 {
   tf2::Quaternion t, q_in;
-  fromMsg(transform.transform.rotation, t);
-  fromMsg(t_in, q_in);
+  tf2::fromMsg<>(transform.transform.rotation, t);
+  tf2::fromMsg<>(t_in, q_in);
 
   tf2::Quaternion q_out = t * q_in;
-  t_out = toMsg(q_out);
+  tf2::toMsg<>(q_out, t_out);
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Quaternion type.
@@ -789,14 +321,14 @@ inline
 void doTransform(const geometry_msgs::Pose& t_in, geometry_msgs::Pose& t_out, const geometry_msgs::TransformStamped& transform)
 {
   tf2::Vector3 v;
-  fromMsg(t_in.position, v);
+  tf2::fromMsg<>(t_in.position, v);
   tf2::Quaternion r;
-  fromMsg(t_in.orientation, r);
+  tf2::fromMsg<>(t_in.orientation, r);
 
   tf2::Transform t;
-  fromMsg(transform.transform, t);
+  tf2::fromMsg<>(transform.transform, t);
   tf2::Transform v_out = t * tf2::Transform(r, v);
-  toMsg(v_out, t_out);
+  tf2::toMsg<>(v_out, t_out);
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Pose type.
@@ -913,14 +445,14 @@ inline
 void doTransform(const geometry_msgs::PoseWithCovarianceStamped& t_in, geometry_msgs::PoseWithCovarianceStamped& t_out, const geometry_msgs::TransformStamped& transform)
 {
   tf2::Vector3 v;
-  fromMsg(t_in.pose.pose.position, v);
+  tf2::fromMsg<>(t_in.pose.pose.position, v);
   tf2::Quaternion r;
-  fromMsg(t_in.pose.pose.orientation, r);
+  tf2::fromMsg<>(t_in.pose.pose.orientation, r);
 
   tf2::Transform t;
-  fromMsg(transform.transform, t);
+  tf2::fromMsg<>(transform.transform, t);
   tf2::Transform v_out = t * tf2::Transform(r, v);
-  toMsg(v_out, t_out.pose.pose);
+  tf2::toMsg<>(v_out, t_out.pose.pose);
   t_out.header.stamp = transform.header.stamp;
   t_out.header.frame_id = transform.header.frame_id;
 
@@ -938,10 +470,10 @@ inline
 void doTransform(const geometry_msgs::TransformStamped& t_in, geometry_msgs::TransformStamped& t_out, const geometry_msgs::TransformStamped& transform)
   {
     tf2::Transform input;
-    fromMsg(t_in.transform, input);
+  tf2::fromMsg<>(t_in.transform, input);
 
     tf2::Transform t;
-    fromMsg(transform.transform, t);
+  tf2::fromMsg<>(transform.transform, t);
     tf2::Transform v_out = t * input;
 
     t_out.transform = toMsg(v_out);
@@ -960,7 +492,7 @@ inline
   void doTransform(const geometry_msgs::Vector3& t_in, geometry_msgs::Vector3& t_out, const geometry_msgs::TransformStamped& transform)
   {
     tf2::Transform t;
-    fromMsg(transform.transform, t);
+  tf2::fromMsg<>(transform.transform, t);
     tf2::Vector3 v_out = t.getBasis() * tf2::Vector3(t_in.x, t_in.y, t_in.z);
     t_out.x = v_out[0];
     t_out.y = v_out[1];
@@ -986,54 +518,25 @@ inline
 /**********************/
 /*** WrenchStamped ****/
 /**********************/
+
+namespace impl
+{
 template <>
-inline
-const ros::Time& getTimestamp(const geometry_msgs::WrenchStamped& t) {return t.header.stamp;}
-
-
-template <>
-inline
-const std::string& getFrameId(const geometry_msgs::WrenchStamped& t) {return t.header.frame_id;}
-
-
-inline
-geometry_msgs::WrenchStamped toMsg(const geometry_msgs::WrenchStamped& in)
+struct ImplDetails<std::array<tf2::Vector3, 2>, geometry_msgs::Wrench>
 {
-  return in;
+  static void toMsg(const std::array<tf2::Vector3, 2>& in, geometry_msgs::Wrench& out)
+{
+    tf2::toMsg(std::get<0>(in), out.force);
+    tf2::toMsg(std::get<1>(in), out.torque);
 }
 
-inline
-void fromMsg(const geometry_msgs::WrenchStamped& msg, geometry_msgs::WrenchStamped& out)
+  static void fromMsg(const geometry_msgs::Wrench& msg, std::array<tf2::Vector3, 2>& out)
 {
-  out = msg;
+    tf2::fromMsg<>(msg.force, std::get<0>(out));
+    tf2::fromMsg<>(msg.torque, std::get<1>(out));
 }
-
-
-inline
-geometry_msgs::WrenchStamped toMsg(const tf2::Stamped<std::array<tf2::Vector3, 2>>& in, geometry_msgs::WrenchStamped & out)
-{
-  out.header.stamp = in.stamp_;
-  out.header.frame_id = in.frame_id_;
-  out.wrench.force = toMsg(in[0]);
-  out.wrench.torque = toMsg(in[1]);
-  return out;
-}
-
-
-inline
-void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<std::array<tf2::Vector3, 2>>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  tf2::Vector3 tmp;
-  fromMsg(msg.wrench.force, tmp);
-  tf2::Vector3 tmp1;
-  fromMsg(msg.wrench.torque, tmp1);
-  std::array<tf2::Vector3, 2> tmp_array;
-  tmp_array[0] = tmp;
-  tmp_array[1] = tmp1;
-  out.setData(tmp_array);
-}
+};
+}  // namespace impl
 
 template<>
 inline

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -86,37 +86,53 @@ inline
     t_out = tf2::Stamped<KDL::Vector>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
 
-/** \brief Convert a stamped KDL Vector type to a PointStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped KDL Vector to convert.
- * \return The vector converted to a PointStamped message.
- */
-inline
-geometry_msgs::PointStamped toMsg(const tf2::Stamped<KDL::Vector>& in)
+namespace impl
 {
-  geometry_msgs::PointStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.point.x = in[0];
-  msg.point.y = in[1];
-  msg.point.z = in[2];
-  return msg;
-}
+template <class Msg>
+struct KDLVectorImplDetails
+{
+  /** \brief Convert a stamped KDL Vector type to a PointStamped message.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in The timestamped KDL Vector to convert.
+   * \return The vector converted to a PointStamped message.
+   */
+  static void toMsg(const KDL::Vector& in, Msg& msg)
+  {
+    msg.x = in[0];
+    msg.y = in[1];
+    msg.z = in[2];
+  }
 
-/** \brief Convert a PointStamped message type to a stamped KDL-specific Vector type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
- * \param msg The PointStamped message to convert.
- * \param out The point converted to a timestamped KDL Vector.
- */
-inline
-void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<KDL::Vector>& out)
+  /** \brief Convert a PointStamped message type to a stamped KDL-specific Vector type.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h
+   * \param msg The PointStamped message to convert.
+   * \param out The point converted to a timestamped KDL Vector.
+   */
+  static void fromMsg(const Msg& msg, KDL::Vector& out)
+  {
+    out[0] = msg.x;
+    out[1] = msg.y;
+    out[2] = msg.z;
+  }
+};
+
+template <>
+struct ImplDetails<KDL::Vector, geometry_msgs::Vector3> : KDLVectorImplDetails<geometry_msgs::Vector3>
 {
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out[0] = msg.point.x;
-  out[1] = msg.point.y;
-  out[2] = msg.point.z;
-}
+};
+
+template <>
+struct ImplDetails<KDL::Vector, geometry_msgs::Point> : KDLVectorImplDetails<geometry_msgs::Point>
+{
+};
+
+template <>
+struct defaultMessage<KDL::Vector>
+{
+  using type = geometry_msgs::Point;
+};
+
+}  // namespace impl
 
 // ---------------------
 // Twist
@@ -133,46 +149,42 @@ inline
   {
     t_out = tf2::Stamped<KDL::Twist>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
-
-/** \brief Convert a stamped KDL Twist type to a TwistStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped KDL Twist to convert.
- * \return The twist converted to a TwistStamped message.
- */
-inline
-geometry_msgs::TwistStamped toMsg(const tf2::Stamped<KDL::Twist>& in)
+namespace impl
 {
-  geometry_msgs::TwistStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.twist.linear.x = in.vel[0];
-  msg.twist.linear.y = in.vel[1];
-  msg.twist.linear.z = in.vel[2];
-  msg.twist.angular.x = in.rot[0];
-  msg.twist.angular.y = in.rot[1];
-  msg.twist.angular.z = in.rot[2];
-  return msg;
-}
-
-/** \brief Convert a TwistStamped message type to a stamped KDL-specific Twist type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
- * \param msg The TwistStamped message to convert.
- * \param out The twist converted to a timestamped KDL Twist.
- */
-inline
-void fromMsg(const geometry_msgs::TwistStamped& msg, tf2::Stamped<KDL::Twist>& out)
+template <>
+struct ImplDetails<KDL::Twist, geometry_msgs::TwistStamped>
 {
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out.vel[0] = msg.twist.linear.x;
-  out.vel[1] = msg.twist.linear.y;
-  out.vel[2] = msg.twist.linear.z;
-  out.rot[0] = msg.twist.angular.x;
-  out.rot[1] = msg.twist.angular.y;
-  out.rot[2] = msg.twist.angular.z;
-}
+  /** \brief Convert a stamped KDL Twist type to a TwistStamped message.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in The timestamped KDL Twist to convert.
+   * \return The twist converted to a TwistStamped message.
+   */
+  static void toMsg(const KDL::Twist& in, geometry_msgs::Twist& msg)
+  {
+    msg.linear.x = in.vel[0];
+    msg.linear.y = in.vel[1];
+    msg.linear.z = in.vel[2];
+    msg.angular.x = in.rot[0];
+    msg.angular.y = in.rot[1];
+    msg.angular.z = in.rot[2];
+  }
 
-
+  /** \brief Convert a TwistStamped message type to a stamped KDL-specific Twist type.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h
+   * \param msg The TwistStamped message to convert.
+   * \param out The twist converted to a timestamped KDL Twist.
+   */
+  static void fromMsg(const geometry_msgs::Twist& msg, KDL::Twist& out)
+  {
+    out.vel[0] = msg.linear.x;
+    out.vel[1] = msg.linear.y;
+    out.vel[2] = msg.linear.z;
+    out.rot[0] = msg.angular.x;
+    out.rot[1] = msg.angular.y;
+    out.rot[2] = msg.angular.z;
+  }
+};
+}  // namespace impl
 // ---------------------
 // Wrench
 // ---------------------
@@ -189,47 +201,42 @@ inline
     t_out = tf2::Stamped<KDL::Wrench>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
 
-/** \brief Convert a stamped KDL Wrench type to a WrenchStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped KDL Wrench to convert.
- * \return The wrench converted to a WrenchStamped message.
- */
-inline
-geometry_msgs::WrenchStamped toMsg(const tf2::Stamped<KDL::Wrench>& in)
+namespace impl
 {
-  geometry_msgs::WrenchStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.wrench.force.x = in.force[0];
-  msg.wrench.force.y = in.force[1];
-  msg.wrench.force.z = in.force[2];
-  msg.wrench.torque.x = in.torque[0];
-  msg.wrench.torque.y = in.torque[1];
-  msg.wrench.torque.z = in.torque[2];
-  return msg;
-}
-
-/** \brief Convert a WrenchStamped message type to a stamped KDL-specific Wrench type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
- * \param msg The WrenchStamped message to convert.
- * \param out The wrench converted to a timestamped KDL Wrench.
- */
-inline
-void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<KDL::Wrench>& out)
+template <>
+struct ImplDetails<KDL::Wrench, geometry_msgs::WrenchStamped>
 {
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  out.force[0] = msg.wrench.force.x;
-  out.force[1] = msg.wrench.force.y;
-  out.force[2] = msg.wrench.force.z;
-  out.torque[0] = msg.wrench.torque.x;
-  out.torque[1] = msg.wrench.torque.y;
-  out.torque[2] = msg.wrench.torque.z;
-}
+  /** \brief Convert a stamped KDL Wrench type to a WrenchStamped message.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in The timestamped KDL Wrench to convert.
+   * \return The wrench converted to a WrenchStamped message.
+   */
+  static void toMsg(const KDL::Wrench& in, geometry_msgs::Wrench& msg)
+  {
+    msg.force.x = in.force[0];
+    msg.force.y = in.force[1];
+    msg.force.z = in.force[2];
+    msg.torque.x = in.torque[0];
+    msg.torque.y = in.torque[1];
+    msg.torque.z = in.torque[2];
+  }
 
-
-
-
+  /** \brief Convert a WrenchStamped message type to a stamped KDL-specific Wrench type.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h
+   * \param msg The WrenchStamped message to convert.
+   * \param out The wrench converted to a timestamped KDL Wrench.
+   */
+  static void fromMsg(const geometry_msgs::Wrench& msg, KDL::Wrench& out)
+  {
+    out.force[0] = msg.force.x;
+    out.force[1] = msg.force.y;
+    out.force[2] = msg.force.z;
+    out.torque[0] = msg.torque.x;
+    out.torque[1] = msg.torque.y;
+    out.torque[2] = msg.torque.z;
+  }
+};
+}  // namespace impl
 // ---------------------
 // Frame
 // ---------------------
@@ -245,64 +252,38 @@ inline
   {
     t_out = tf2::Stamped<KDL::Frame>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
-
-/** \brief Convert a stamped KDL Frame type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped KDL Frame to convert.
- * \return The frame converted to a Pose message.
- */
-inline
-geometry_msgs::Pose toMsg(const KDL::Frame& in)
+namespace impl
 {
-  geometry_msgs::Pose msg;
-  msg.position.x = in.p[0];
-  msg.position.y = in.p[1];
-  msg.position.z = in.p[2];
-  in.M.GetQuaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
-  return msg;
-}
-
-/** \brief Convert a Pose message type to a KDL Frame.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg The Pose message to convert.
- * \param out The pose converted to a KDL Frame.
- */
-inline
-void fromMsg(const geometry_msgs::Pose& msg, KDL::Frame& out)
+template <>
+struct ImplDetails<KDL::Frame, geometry_msgs::Pose>
 {
-  out.p[0] = msg.position.x;
-  out.p[1] = msg.position.y;
-  out.p[2] = msg.position.z;
-  out.M = KDL::Rotation::Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
-}
+  /** \brief Convert a stamped KDL Frame type to a Pose message.
+   * This function is a specialization of the toMsg template defined in tf2/convert.h.
+   * \param in The timestamped KDL Frame to convert.
+   * \return The frame converted to a Pose message.
+   */
+  static void toMsg(const KDL::Frame& in, geometry_msgs::Pose& msg)
+  {
+    msg.position.x = in.p[0];
+    msg.position.y = in.p[1];
+    msg.position.z = in.p[2];
+    in.M.GetQuaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+  }
 
-/** \brief Convert a stamped KDL Frame type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param in The timestamped KDL Frame to convert.
- * \return The frame converted to a PoseStamped message.
- */
-inline
-geometry_msgs::PoseStamped toMsg(const tf2::Stamped<KDL::Frame>& in)
-{
-  geometry_msgs::PoseStamped msg;
-  msg.header.stamp = in.stamp_;
-  msg.header.frame_id = in.frame_id_;
-  msg.pose = toMsg(static_cast<const KDL::Frame&>(in));
-  return msg;
-}
-
-/** \brief Convert a Pose message transform type to a stamped KDL Frame.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
- * \param msg The PoseStamped message to convert.
- * \param out The pose converted to a timestamped KDL Frame.
- */
-inline
-void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<KDL::Frame>& out)
-{
-  out.stamp_ = msg.header.stamp;
-  out.frame_id_ = msg.header.frame_id;
-  fromMsg(msg.pose, static_cast<KDL::Frame&>(out));
-}
+  /** \brief Convert a Pose message type to a KDL Frame.
+   * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+   * \param msg The Pose message to convert.
+   * \param out The pose converted to a KDL Frame.
+   */
+  static void fromMsg(const geometry_msgs::Pose& msg, KDL::Frame& out)
+  {
+    out.p[0] = msg.position.x;
+    out.p[1] = msg.position.y;
+    out.p[2] = msg.position.z;
+    out.M = KDL::Rotation::Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
+  }
+};
+}  // namespace impl
 
 } // namespace
 

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -152,7 +152,7 @@ inline
 namespace impl
 {
 template <>
-struct ImplDetails<KDL::Twist, geometry_msgs::TwistStamped>
+struct ImplDetails<KDL::Twist, geometry_msgs::Twist>
 {
   /** \brief Convert a stamped KDL Twist type to a TwistStamped message.
    * This function is a specialization of the toMsg template defined in tf2/convert.h.
@@ -184,6 +184,13 @@ struct ImplDetails<KDL::Twist, geometry_msgs::TwistStamped>
     out.rot[2] = msg.angular.z;
   }
 };
+
+template <>
+struct defaultMessage<KDL::Twist>
+{
+  using type = geometry_msgs::Twist;
+};
+
 }  // namespace impl
 // ---------------------
 // Wrench
@@ -204,7 +211,7 @@ inline
 namespace impl
 {
 template <>
-struct ImplDetails<KDL::Wrench, geometry_msgs::WrenchStamped>
+struct ImplDetails<KDL::Wrench, geometry_msgs::Wrench>
 {
   /** \brief Convert a stamped KDL Wrench type to a WrenchStamped message.
    * This function is a specialization of the toMsg template defined in tf2/convert.h.
@@ -235,6 +242,12 @@ struct ImplDetails<KDL::Wrench, geometry_msgs::WrenchStamped>
     out.torque[1] = msg.torque.y;
     out.torque[2] = msg.torque.z;
   }
+};
+
+template <>
+struct defaultMessage<KDL::Wrench>
+{
+  using type = geometry_msgs::Wrench;
 };
 }  // namespace impl
 // ---------------------

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -252,6 +252,7 @@ inline
   {
     t_out = tf2::Stamped<KDL::Frame>(transformToKDL(transform) * t_in, transform.header.stamp, transform.header.frame_id);
   }
+
 namespace impl
 {
 template <>
@@ -282,6 +283,12 @@ struct ImplDetails<KDL::Frame, geometry_msgs::Pose>
     out.p[2] = msg.position.z;
     out.M = KDL::Rotation::Quaternion(msg.orientation.x, msg.orientation.y, msg.orientation.z, msg.orientation.w);
   }
+};
+
+template <>
+struct defaultMessage<KDL::Frame>
+{
+  using type = geometry_msgs::Pose;
 };
 }  // namespace impl
 

--- a/tf2_ros/src/buffer.cpp
+++ b/tf2_ros/src/buffer.cpp
@@ -78,7 +78,7 @@ ros::Time now_fallback_to_wall()
   {
     return ros::Time::now();
   }
-  catch (ros::TimeNotInitializedException ex)
+  catch (const ros::TimeNotInitializedException&)
   {
     ros::WallTime wt = ros::WallTime::now(); 
     return ros::Time(wt.sec, wt.nsec); 
@@ -96,7 +96,7 @@ void sleep_fallback_to_wall(const ros::Duration& d)
   {
       d.sleep();
   }
-  catch (ros::TimeNotInitializedException ex)
+  catch (const ros::TimeNotInitializedException&)
   {
     ros::WallDuration wd = ros::WallDuration(d.sec, d.nsec); 
     wd.sleep();

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -91,16 +91,6 @@ void doTransform(const sensor_msgs::PointCloud2 &p_in, sensor_msgs::PointCloud2 
     *z_out = point.z();
   }
 }
-inline
-sensor_msgs::PointCloud2 toMsg(const sensor_msgs::PointCloud2 &in)
-{
-  return in;
-}
-inline
-void fromMsg(const sensor_msgs::PointCloud2 &msg, sensor_msgs::PointCloud2 &out)
-{
-  out = msg;
-}
 
 } // namespace
 


### PR DESCRIPTION
The second template parameter of `tf2::toMsg()` now has a default value,
which is resolved to a ROS message type depending on the non-message datatype.
This allows the deduction of the return value type.

Furthermore, `toMsg()`,  `fromMsg()`, `getTimestamp()` and `getFrameId()` now have a default implementation,
which forwards the calls into structs defined in the impl namespace. Now missing implementations of conversion methods result in compile-time errors, they do not occur during link-time anymore.

A lot of effort was put into the automatic conversion of dataypes with a stamp (`tf2::Stamped<T>` and the ...Stamped ROS messages) to avoid code duplication. The stamped types now use the conversion methods of the unstamped types and copy the timestamp/frame id informations.

This PR should remain API compatibility, but the ABI will break (as the non-templated functions like `toMsg()` are removed).

Further TODO's:

  - [ ] extend documentation
  - [ ] test downstream packages

@seanyen may I ask you to test whether this approach works on Windows?

Related Issues:
#430
ros-planning/moveit#1785
