### PR TITLE
Fix Python Linking on OSX

### DIFF
--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -88,8 +88,9 @@ catkin_package(
 
 # Dynamic linking with tf worked OK, except for exception propagation, which failed in the unit test.
 # so build with the objects directly instead.
-
-link_libraries(${PYTHON_LIBRARIES})
+if(NOT APPLE)
+  link_libraries(${PYTHON_LIBRARIES})
+endif()
 add_library(tf2_py src/tf2_py.cpp)
 target_link_libraries(tf2_py ${catkin_LIBRARIES})
 add_dependencies(tf2_py ${catkin_EXPORTED_TARGETS})
@@ -100,6 +101,10 @@ if(WIN32)
 else()
   set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
+endif()
+if(APPLE)
+  set_target_properties(${PROJECT_NAME}_boost PROPERTIES
+                        LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 set_target_properties(tf2_py PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -101,10 +101,10 @@ if(WIN32)
 else()
   set_target_properties(tf2_py PROPERTIES COMPILE_FLAGS "-g -Wno-missing-field-initializers")
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
-endif()
-if(APPLE)
-  set_target_properties(tf2_py PROPERTIES
-                        LINK_FLAGS "-undefined dynamic_lookup")
+  if(APPLE)
+    set_target_properties(tf2_py PROPERTIES
+                          LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
 endif()
 set_target_properties(tf2_py PROPERTIES
   ARCHIVE_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION}

--- a/tf2_py/CMakeLists.txt
+++ b/tf2_py/CMakeLists.txt
@@ -103,7 +103,7 @@ else()
   set_target_properties(tf2_py PROPERTIES OUTPUT_NAME tf2 PREFIX "_" SUFFIX ".so")
 endif()
 if(APPLE)
-  set_target_properties(${PROJECT_NAME}_boost PROPERTIES
+  set_target_properties(tf2_py PROPERTIES
                         LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 set_target_properties(tf2_py PROPERTIES


### PR DESCRIPTION
In https://github.com/RoboStack/ros-noetic/issues/86 we discovered that `import tf2_py` results in a segmentation fault on OSX. We previously observed similar issues with cv_bridge: https://github.com/ros-perception/vision_opencv/pull/331 which also contains links to why the proposed solution here works (see https://github.com/pytorch/pytorch/commit/73f6715f4725a0723d8171d3131e09ac7abf0666).