### PR TITLE
added missing package dependencies of tf2/utils

### DIFF
--- a/tf2/CMakeLists.txt
+++ b/tf2/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.0.2)
 project(tf2)
 
 find_package(console_bridge REQUIRED)
-find_package(catkin REQUIRED COMPONENTS geometry_msgs rostime tf2_msgs)
+find_package(catkin REQUIRED COMPONENTS geometry_msgs rostime tf2_msgs tf2_geometry_msgs)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 catkin_package(
    INCLUDE_DIRS include
    LIBRARIES tf2
    DEPENDS console_bridge
-   CATKIN_DEPENDS geometry_msgs tf2_msgs rostime)
+   CATKIN_DEPENDS geometry_msgs tf2_msgs tf2_geometry_msgs rostime)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS})
 

--- a/tf2/package.xml
+++ b/tf2/package.xml
@@ -23,11 +23,13 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>rostime</build_depend>
   <build_depend>tf2_msgs</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>libconsole-bridge-dev</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>rostime</run_depend>
   <run_depend>tf2_msgs</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
 
 </package>
 


### PR DESCRIPTION
tf2/utils.h depends on tf2_geometry_msgs https://github.com/ros/geometry2/blob/noetic-devel/tf2/include/tf2/impl/utils.h#L18
So it should be added as a package dependency.