### PR TITLE
Invert echo terminology to make tf2_tools echo.py coherent with the rest of the API

### DIFF
--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -167,8 +167,8 @@ class Echo():
             lookup_time = rospy.Time()
 
         try:
-            ts = self.tf_buffer.lookup_transform(self.args.source_frame,
-                                                 self.args.target_frame,
+            ts = self.tf_buffer.lookup_transform(self.args.target_frame,
+                                                 self.args.source_frame,
                                                  lookup_time)
         except tf2.LookupException as ex:
             msg = "At time {}, (current time {}) ".format(lookup_time.to_sec(), cur_time.to_sec())
@@ -222,8 +222,8 @@ if __name__ == '__main__':
         pass
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("source_frame")  # parent
-    parser.add_argument("target_frame")  # child
+    parser.add_argument("target_frame")
+    parser.add_argument("source_frame")
     parser.add_argument("-r", "--rate",
                         help="update rate, must be > 0.0",
                         default=1.0,

--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -221,7 +221,8 @@ if __name__ == '__main__':
     except KeyError:
         pass
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Display at a regular interval the coordinate of source_frame into target_frame.")
     parser.add_argument("target_frame")
     parser.add_argument("source_frame")
     parser.add_argument("-r", "--rate",


### PR DESCRIPTION
This is my proposition to improve coherence between tf2_tools echo.py and the rest of the API while not breaking backward compatibility.

If this is accepted, I will do the same on tf echo for ros/geometry.

Closes #510.