### PR TITLE
Add transform broadcaster constructors which can take a node handle as an argument.

### DIFF
--- a/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/static_transform_broadcaster.h
@@ -52,6 +52,9 @@ public:
   /** \brief Constructor (needs a ros::Node reference) */
   StaticTransformBroadcaster();
 
+  /** \brief Constructor (needs a ros::Node reference) */
+  StaticTransformBroadcaster(const ros::NodeHandle& node);
+
   /** \brief Send a TransformStamped message
    * The stamped data structure includes frame_id, and time, and parent_id already.  */
   void sendTransform(const geometry_msgs::TransformStamped & transform) {

--- a/tf2_ros/include/tf2_ros/transform_broadcaster.h
+++ b/tf2_ros/include/tf2_ros/transform_broadcaster.h
@@ -50,6 +50,9 @@ public:
   /** \brief Constructor (needs a ros::Node reference) */
   TransformBroadcaster();
 
+  /** \brief Constructor (needs a ros::Node reference) */
+  TransformBroadcaster(const ros::NodeHandle& node);
+
   /** \brief Send a StampedTransform 
    * The stamped data structure includes frame_id, and time, and parent_id already.  */
   //  void sendTransform(const StampedTransform & transform);

--- a/tf2_ros/src/static_transform_broadcaster.cpp
+++ b/tf2_ros/src/static_transform_broadcaster.cpp
@@ -43,6 +43,11 @@ StaticTransformBroadcaster::StaticTransformBroadcaster()
   publisher_ = node_.advertise<tf2_msgs::TFMessage>("/tf_static", 100, true);
 };
 
+StaticTransformBroadcaster::StaticTransformBroadcaster(const ros::NodeHandle& node) : node_(node)
+{
+  publisher_ = node_.advertise<tf2_msgs::TFMessage>("/tf_static", 100, true);
+};
+
 void StaticTransformBroadcaster::sendTransform(const std::vector<geometry_msgs::TransformStamped> & msgtf)
 {
   for (const geometry_msgs::TransformStamped& input : msgtf)

--- a/tf2_ros/src/transform_broadcaster.cpp
+++ b/tf2_ros/src/transform_broadcaster.cpp
@@ -42,6 +42,11 @@ TransformBroadcaster::TransformBroadcaster()
   publisher_ = node_.advertise<tf2_msgs::TFMessage>("/tf", 100);
 };
 
+TransformBroadcaster::TransformBroadcaster(const ros::NodeHandle& node) : node_(node)
+{
+  publisher_ = node_.advertise<tf2_msgs::TFMessage>("/tf", 100, true);
+};
+
 void TransformBroadcaster::sendTransform(const geometry_msgs::TransformStamped & msgtf)
 {
   std::vector<geometry_msgs::TransformStamped> v1;


### PR DESCRIPTION
When remapping `/tf` or `/tf_static` for a node or nodelet in roslaunch, the topics are only remapped correctly when the broadcaster is part of a node.  If the broadcaster is part of a nodelet, the topics are not remapped because the broadcasters are publishing on the manager's node handle instead of the nodelet's node handle.

This MR adds new constructors for the transform broadcaster and static transform broadcaster that take in a user provided node handle.   This allows a nodelet to pass it's node handle to the broadcaster constructors.