### PR TITLE
(tf2_ros) Docs working on python 3

### DIFF
--- a/tf2_ros/doc/conf.py
+++ b/tf2_ros/doc/conf.py
@@ -22,7 +22,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/tf2_ros/src/tf2_ros/transform_listener.py
+++ b/tf2_ros/src/tf2_ros/transform_listener.py
@@ -30,10 +30,10 @@
 import threading
 
 import rospy
-import tf2_ros
 from tf2_msgs.msg import TFMessage
 
-class TransformListener():
+
+class TransformListener:
     """
     :class:`TransformListener` is a convenient way to listen for coordinate frame transformation info.
     This class takes an object that instantiates the :class:`BufferInterface` interface, to which
@@ -41,14 +41,14 @@ class TransformListener():
     """
     def __init__(self, buffer, queue_size=None, buff_size=65536, tcp_nodelay=False):
         """
-        .. function:: __init__(buffer)
+        .. function:: __init__(buffer, queue_size=None, buff_size=65536, tcp_nodelay=False):
 
             Constructor.
 
             :param buffer: The buffer to propagate changes to when tf info updates.
-            :param queue_size (int) - maximum number of messages to receive at a time. This will generally be 1 or None (infinite, default). buff_size should be increased if this parameter is set as incoming data still needs to sit in the incoming buffer before being discarded. Setting queue_size buff_size to a non-default value affects all subscribers to this topic in this process.
-            :param buff_size (int) - incoming message buffer size in bytes. If queue_size is set, this should be set to a number greater than the queue_size times the average message size. Setting buff_size to a non-default value affects all subscribers to this topic in this process.
-            :param tcp_nodelay (bool) - if True, request TCP_NODELAY from publisher. Use of this option is not generally recommended in most cases as it is better to rely on timestamps in message data. Setting tcp_nodelay to True enables TCP_NODELAY for all subscribers in the same python process.
+            :param queue_size: Maximum number of messages to receive at a time. This will generally be 1 or None (infinite, default). buff_size should be increased if this parameter is set as incoming data still needs to sit in the incoming buffer before being discarded. Setting queue_size buff_size to a non-default value affects all subscribers to this topic in this process.
+            :param buff_size: Incoming message buffer size in bytes. If queue_size is set, this should be set to a number greater than the queue_size times the average message size. Setting buff_size to a non-default value affects all subscribers to this topic in this process.
+            :param tcp_nodelay: If True, request TCP_NODELAY from publisher. Use of this option is not generally recommended in most cases as it is better to rely on timestamps in message data. Setting tcp_nodelay to True enables TCP_NODELAY for all subscribers in the same python process.
         """
         self.buffer = buffer
         self.last_update = rospy.Time.now()


### PR DESCRIPTION
As suggested by https://github.com/ros/geometry2/issues/497#issuecomment-814169084, `imgmath`, should be used instead of `pngmath`. Also Fixed the styling of the docstring of `transform_listener`.

The page generated locally now looks following:
[tf2_ros.pdf](https://github.com/ros/geometry2/files/7285637/tf2_ros.pdf)

Partial solution for https://github.com/ros/geometry2/issues/497
