### PR TITLE
Restore time difference order so future extrapolation exceptions show positive seconds into future

### DIFF
--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -76,7 +76,9 @@ void createExtrapolationException2(ros::Time t0, ros::Time t1, std::string* erro
 {
   if (error_str)
   {
-    ros::Duration tdiff = t1 - t0;
+    // Want this to come out positive, because this is a future extrapolation problem with t0
+    // t0 needs to come first because it will be bigger than t1
+    ros::Duration tdiff = t0 - t1;
     char str[163]; // Text without formatting strings has 102, each timestamp has up to 20
     snprintf(
         str, sizeof(str),


### PR DESCRIPTION
There was a manual merge 52bff88ecad8821802ad5e04dcb711b582c39f5a as a part of #470  that caused this regression, resulting in negative seconds into the future:

```
tf2.ExtrapolationException: Lookup would require extrapolation -0.041266203s into the future.
```

If the t0 - t1 ordering is confusing could alternatively do `-tdiff.to_sec()`.