### PR TITLE
Fix dead loop in message filter

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1261,7 +1261,11 @@ void BufferCore::removeTransformableCallback(TransformableCallbackHandle handle)
 
   {
     boost::mutex::scoped_lock lock(transformable_requests_mutex_);
-    std::remove_if(transformable_requests_.begin(), transformable_requests_.end(), RemoveRequestByCallback(handle));
+    auto it = std::remove_if(transformable_requests_.begin(), transformable_requests_.end(), RemoveRequestByCallback(handle));
+    if (it != transformable_requests_.end())
+    {
+      transformable_requests_.erase(it, transformable_requests_.end());
+    }
   }
 }
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1337,7 +1337,11 @@ struct BufferCore::RemoveRequestByID
 void BufferCore::cancelTransformableRequest(TransformableRequestHandle handle)
 {
   boost::mutex::scoped_lock lock(transformable_requests_mutex_);
-  std::remove_if(transformable_requests_.begin(), transformable_requests_.end(), RemoveRequestByID(handle));
+  auto it = std::remove_if(transformable_requests_.begin(), transformable_requests_.end(), RemoveRequestByID(handle));
+  if (it != transformable_requests_.end())
+  {
+    transformable_requests_.erase(it, transformable_requests_.end());
+  }
 }
 
 


### PR DESCRIPTION
The bug is introduced in https://github.com/ros/geometry2/pull/461

`std::remove_if()` will only put elements to the back of the vector. One must call erase to actually remove them.