### PR TITLE
remove useless method with misleading doc

### DIFF
--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -668,6 +668,17 @@ geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
   return in;
 }
 
+/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
+ * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * \param msg A TransformStamped message type.
+ * \param out The input argument
+ */
+inline
+void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)
+{
+  out = msg;
+}
+
 /** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
  * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -668,17 +668,6 @@ geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
   return in;
 }
 
-/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A TransformStamped message type.
- * \param out The TransformStamped converted to the equivalent tf2 type.
- */
-inline
-void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)
-{
-  out = msg;
-}
-
 /** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
  * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -667,11 +667,10 @@ geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
 {
   return in;
 }
-
-/** \brief Convert a TransformStamped message to its equivalent tf2 representation.
+/** \brief Trivial "conversion" function for TransformStamped message type.
  * This function is a specialization of the toMsg template defined in tf2/convert.h.
- * \param msg A TransformStamped message type.
- * \param out The input argument
+ * \param msg A TransformStamped message.
+ * \param out The input argument.
  */
 inline
 void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::TransformStamped& out)


### PR DESCRIPTION
The overload 

`void tf2::fromMsg ( const geometry_msgs::TransformStamped & msg, geometry_msgs::TransformStamped &)`

seems to be useless since it consists of a call to the copy constructor only. Nonetheless, its documentation is wrong.