### PR TITLE
Bugfix: SetEuler/SetRPY implementations were differing

### DIFF
--- a/tf2/include/tf2/LinearMath/Quaternion.h
+++ b/tf2/include/tf2/LinearMath/Quaternion.h
@@ -83,10 +83,10 @@ public:
 		tf2Scalar sinPitch = tf2Sin(halfPitch);
 		tf2Scalar cosRoll = tf2Cos(halfRoll);
 		tf2Scalar sinRoll = tf2Sin(halfRoll);
-		setValue(cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw,
-			cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw,
-			sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw,
-			cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw);
+		setValue(sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw, //x
+                         cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw, //y
+                         cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw, //z
+                         cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw); //formerly yzx
 	}
   /**@brief Set the quaternion using fixed axis RPY
    * @param roll Angle around X 

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -325,6 +325,28 @@ TEST(Bullet, Slerp)
 
 }
 
+TEST(TimeCache, SetRPYEqualsSetEuler)
+{
+  uint64_t runs = 100;
+  seed_rand();
+
+  tf2::Quaternion q1, q2;
+  double yaw, pitch, roll;
+
+  for (uint64_t i = 0; i < runs; i++) {
+    yaw = 1.0 * get_rand();
+    pitch = 1.0 * get_rand();
+    roll = 1.0 * get_rand();
+
+    q1.setEuler(yaw, pitch, roll);
+    q2.setRPY(roll, pitch, yaw);
+
+    EXPECT_NEAR(q1.x(), q2.x(), 1e-5);
+    EXPECT_NEAR(q1.y(), q2.y(), 1e-5);
+    EXPECT_NEAR(q1.z(), q2.z(), 1e-5);
+    EXPECT_NEAR(q1.w(), q2.w(), 1e-5);
+  }
+}
 
 TEST(TimeCache, AngularInterpolation)
 {


### PR DESCRIPTION
Hi there, small bug fix along with a unit test.

SetEuler takes yaw, pitch, roll as parameters in that order, SetRPY takes roll, pitch, yaw in that order. They should produce the same Quaternion when passed the same yaw/pitch/roll in the right respective order, but it doesn't.
The explanation is simple: SetEuler and SetRPY don't have the same implementation even though they should (the order changes but the way to calculate the Quaternions stay the same).

In the current implementation, the unit test I added was failing, now it's not.