### PR TITLE
Fix race condition in MessageFilter

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -1462,7 +1462,7 @@ void BufferCore::testTransformableRequests()
     }
   }
 
-  // unlock before allowing possible user callbacks to avoid potential detadlock (#91)
+  // unlock before allowing possible user callbacks to avoid potential deadlock (#91)
   lock.unlock();
 
   // Backwards compatability callback for tf

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -37,7 +37,6 @@
 #include <assert.h>
 #include <console_bridge/console.h>
 #include "tf2/LinearMath/Transform.h"
-#include <boost/foreach.hpp>
 
 namespace tf2
 {
@@ -1406,11 +1405,6 @@ void BufferCore::testTransformableRequests()
 {
   boost::mutex::scoped_lock lock(transformable_requests_mutex_);
   V_TransformableRequest::iterator it = transformable_requests_.begin();
-
-  typedef boost::tuple<TransformableCallback&, TransformableRequestHandle, std::string,
-                       std::string, ros::Time&, TransformableResult&> TransformableTuple;
-  std::vector<TransformableTuple> transformables;
-
   for (; it != transformable_requests_.end();)
   {
     TransformableRequest& req = *it;
@@ -1450,12 +1444,8 @@ void BufferCore::testTransformableRequests()
         M_TransformableCallback::iterator it = transformable_callbacks_.find(req.cb_handle);
         if (it != transformable_callbacks_.end())
         {
-          transformables.push_back(boost::make_tuple(boost::ref(it->second),
-                                                     req.request_handle,
-                                                     lookupFrameString(req.target_id),
-                                                     lookupFrameString(req.source_id),
-                                                     boost::ref(req.time),
-                                                     boost::ref(result)));
+          const TransformableCallback& cb = it->second;
+          cb(req.request_handle, lookupFrameString(req.target_id), lookupFrameString(req.source_id), req.time, result);
         }
       }
 
@@ -1472,13 +1462,8 @@ void BufferCore::testTransformableRequests()
     }
   }
 
-  // unlock before allowing possible user callbacks to avoid potential deadlock (#91)
+  // unlock before allowing possible user callbacks to avoid potential detadlock (#91)
   lock.unlock();
-
-  BOOST_FOREACH (TransformableTuple tt, transformables)
-  {
-    tt.get<0>()(tt.get<1>(), tt.get<2>(), tt.get<3>(), tt.get<4>(), tt.get<5>());
-  }
 
   // Backwards compatability callback for tf
   _transforms_changed_();

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -372,12 +372,10 @@ public:
     }
     else
     {
+      boost::unique_lock<boost::shared_mutex> unique_lock(messages_mutex_);
       // If this message is about to push us past our queue size, erase the oldest message
       if (queue_size_ != 0 && message_count_ + 1 > queue_size_)
       {
-        // While we're using the reference keep a shared lock on the messages.
-        boost::shared_lock< boost::shared_mutex > shared_lock(messages_mutex_);
-
         ++dropped_message_count_;
         const MessageInfo& front = messages_.front();
         TF2_ROS_MESSAGEFILTER_DEBUG("Removed oldest message because buffer is full, count now %d (frame_id=%s, stamp=%f)", message_count_,
@@ -391,20 +389,13 @@ public:
         }
 
         messageDropped(front.event, filter_failure_reasons::Unknown);
-        // Unlock the shared lock and get a unique lock. Upgradeable lock is used in transformable.
-        // There can only be one upgrade lock. It's important the cancelTransformableRequest not deadlock with transformable.
-        // They both require the transformable_requests_mutex_ in BufferCore.
-        shared_lock.unlock();
-        // There is a very slight race condition if an older message arrives in this gap.
-        boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
+
         messages_.pop_front();
-         --message_count_;
+        --message_count_;
       }
 
       // Add the message to our list
       info.event = evt;
-      // Lock access to the messages_ before modifying them.
-      boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
       messages_.push_back(info);
       ++message_count_;
     }
@@ -471,7 +462,7 @@ private:
   {
     namespace mt = ros::message_traits;
 
-    boost::upgrade_lock< boost::shared_mutex > lock(messages_mutex_);
+    boost::upgrade_lock<boost::shared_mutex> read_lock(messages_mutex_);
 
     // find the message this request is associated with
     typename L_MessageInfo::iterator msg_it = messages_.begin();
@@ -534,8 +525,6 @@ private:
       can_transform = false;
     }
 
-    // We will be mutating messages now, require unique lock
-    boost::upgrade_to_unique_lock< boost::shared_mutex > uniqueLock(lock);
     if (can_transform)
     {
       TF2_ROS_MESSAGEFILTER_DEBUG("Message ready in frame %s at time %.3f, count now %d", frame_id.c_str(), stamp.toSec(), message_count_ - 1);
@@ -553,6 +542,8 @@ private:
       messageDropped(info.event, filter_failure_reasons::Unknown);
     }
 
+    // We will be mutating messages now, require unique lock
+    boost::upgrade_to_unique_lock<boost::shared_mutex> write_lock(read_lock);
     messages_.erase(msg_it);
     --message_count_;
   }

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -215,8 +215,8 @@ public:
   ~MessageFilter()
   {
     message_connection_.disconnect();
-
     MessageFilter::clear();
+    bc_.removeTransformableCallback(callback_handle_);
 
     TF2_ROS_MESSAGEFILTER_DEBUG("Successful Transforms: %llu, Discarded due to age: %llu, Transform messages received: %llu, Messages received: %llu, Total dropped: %llu",
                            (long long unsigned int)successful_transform_count_,

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -278,13 +278,11 @@ public:
    */
   void clear()
   {
-    boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
-
-    TF2_ROS_MESSAGEFILTER_DEBUG("%s", "Cleared");
-
     bc_.removeTransformableCallback(callback_handle_);
     callback_handle_ = bc_.addTransformableCallback(boost::bind(&MessageFilter::transformable, this, _1, _2, _3, _4, _5));
 
+    // acquire after remove/addTransformableCallback to avoid deadlock!
+    boost::unique_lock<boost::shared_mutex> unique_lock(messages_mutex_);
     messages_.clear();
     message_count_ = 0;
 
@@ -293,6 +291,7 @@ public:
       callback_queue_->removeByID((uint64_t)this);
 
     warned_about_empty_frame_id_ = false;
+    TF2_ROS_MESSAGEFILTER_DEBUG("%s", "Cleared");
   }
 
   void add(const MEvent& evt)

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -372,10 +372,12 @@ public:
     }
     else
     {
-      boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
       // If this message is about to push us past our queue size, erase the oldest message
       if (queue_size_ != 0 && message_count_ + 1 > queue_size_)
       {
+        // While we're using the reference keep a shared lock on the messages.
+        boost::shared_lock< boost::shared_mutex > shared_lock(messages_mutex_);
+
         ++dropped_message_count_;
         const MessageInfo& front = messages_.front();
         TF2_ROS_MESSAGEFILTER_DEBUG("Removed oldest message because buffer is full, count now %d (frame_id=%s, stamp=%f)", message_count_,
@@ -383,19 +385,26 @@ public:
 
         V_TransformableRequestHandle::const_iterator it = front.handles.begin();
         V_TransformableRequestHandle::const_iterator end = front.handles.end();
-
         for (; it != end; ++it)
         {
           bc_.cancelTransformableRequest(*it);
         }
 
         messageDropped(front.event, filter_failure_reasons::Unknown);
+        // Unlock the shared lock and get a unique lock. Upgradeable lock is used in transformable.
+        // There can only be one upgrade lock. It's important the cancelTransformableRequest not deadlock with transformable.
+        // They both require the transformable_requests_mutex_ in BufferCore.
+        shared_lock.unlock();
+        // There is a very slight race condition if an older message arrives in this gap.
+        boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
         messages_.pop_front();
          --message_count_;
       }
 
       // Add the message to our list
       info.event = evt;
+      // Lock access to the messages_ before modifying them.
+      boost::unique_lock< boost::shared_mutex > unique_lock(messages_mutex_);
       messages_.push_back(info);
       ++message_count_;
     }

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -158,7 +158,6 @@ protected:
     Sink(const std::string &name, int delay = 0) : name_(name), delay_(delay) {}
     void operator()(const boost::shared_ptr<const M> &msg)
     {
-      std::cerr << name_ << " ";
       std::this_thread::sleep_for(std::chrono::milliseconds(delay_));
     }
   };
@@ -170,7 +169,6 @@ public:
     const std::string frame_id("target");
     while (ros::ok() && run)
     {
-      std::cerr << "\ngenerated: ";
       source.generate(frame_id, ros::Time::now());
       rate.sleep();
     }
@@ -231,7 +229,6 @@ TEST_P(MessageFilterFixture, StressTest)
   while (!filters.empty())
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(7));
-    std::cerr << "\033[31m" << filters.front().getName() << "\033[0m ";
     filters.pop_front();
   }
 

--- a/tf2_ros/test/message_filter_test.cpp
+++ b/tf2_ros/test/message_filter_test.cpp
@@ -118,6 +118,129 @@ TEST(tf2_ros_message_filter, multiple_frames_and_time_tolerance)
   ASSERT_TRUE(filter_callback_fired);
 }
 
+template <class M>
+class MessageGenerator : public message_filters::SimpleFilter<M>
+{
+public:
+  template <typename F>
+  void connectInput(F &)
+  {
+  }
+
+  void add(const ros::MessageEvent<M const> &)
+  {
+  }
+
+  void generate(const std::string &frame_id, const ros::Time &time)
+  {
+    auto msg = boost::make_shared<M>();
+    msg->header.frame_id = frame_id;
+    msg->header.stamp = time;
+    this->signalMessage(msg);
+  }
+};
+
+class MessageFilterFixture : public ::testing::TestWithParam<bool>
+{
+  using M = geometry_msgs::PointStamped;
+
+protected:
+  tf2_ros::Buffer buffer;
+  MessageGenerator<M> source;
+  std::list<tf2_ros::MessageFilter<M>> filters;
+  bool run = true;
+
+  struct Sink
+  {
+    std::string name_;
+    int delay_;
+
+    Sink(const std::string &name, int delay = 0) : name_(name), delay_(delay) {}
+    void operator()(const boost::shared_ptr<const M> &msg)
+    {
+      std::cerr << name_ << " ";
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay_));
+    }
+  };
+
+public:
+  void msg_gen()
+  {
+    ros::WallRate rate(100); // publish messages @ 100Hz
+    const std::string frame_id("target");
+    while (ros::ok() && run)
+    {
+      std::cerr << "\ngenerated: ";
+      source.generate(frame_id, ros::Time::now());
+      rate.sleep();
+    }
+  };
+
+  void frame_gen()
+  {
+    ros::WallRate rate(50); // publish frame info @ 50 Hz (slower than msgs)
+    while (ros::ok() && run)
+    {
+      geometry_msgs::TransformStamped transform;
+      transform.header.stamp = ros::Time::now();
+      transform.header.frame_id = "base";
+      transform.child_frame_id = "target";
+      transform.transform.translation.x = 0.0;
+      transform.transform.translation.y = 0.0;
+      transform.transform.translation.z = 0.0;
+      transform.transform.rotation.x = 0.0;
+      transform.transform.rotation.y = 0.0;
+      transform.transform.rotation.z = 0.0;
+      transform.transform.rotation.w = 1.0;
+      buffer.setTransform(transform, "frame_generator", false);
+      rate.sleep();
+    }
+  };
+
+  void add_filter(int i, ros::CallbackQueueInterface *queue)
+  {
+    std::string name(queue ? "Q" : "S");
+    name += std::to_string(i);
+
+    filters.emplace_back(buffer, "base", i + 1, queue);
+    auto &f = filters.back();
+    f.setName(name);
+    f.connectInput(source);
+    f.registerCallback(Sink(name, 1));
+  };
+};
+
+TEST_P(MessageFilterFixture, StressTest)
+{
+  ros::NodeHandle nh;
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  std::thread msg_gen(&MessageFilterFixture::msg_gen, this);
+  std::thread frame_gen(&MessageFilterFixture::frame_gen, this);
+
+  bool use_cbqueue = GetParam();
+  ros::CallbackQueueInterface *queue = use_cbqueue ? nh.getCallbackQueue() : nullptr;
+  // use fewer filters for signal-only transmission as we can remove only a single filter per iteration
+  int num_filters = use_cbqueue ? 50 : 10;
+  for (int i = 0; i < num_filters; ++i)
+    add_filter(i, queue);
+
+  // slowly remove filters
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  while (!filters.empty())
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(7));
+    std::cerr << "\033[31m" << filters.front().getName() << "\033[0m ";
+    filters.pop_front();
+  }
+
+  run = false;
+  msg_gen.join();
+  frame_gen.join();
+}
+INSTANTIATE_TEST_CASE_P(MessageFilterTests, MessageFilterFixture, ::testing::Values(false, true));
+
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "tf2_ros_message_filter");


### PR DESCRIPTION
A bug reported in https://github.com/ros-visualization/rviz/issues/1753 pointed to race condition(s) in `tf2_ros::MessageFilter`.
I implemented a stress test to analyze the problem in detail. There were two issues:
1. A race condition routing back to #91, #101, #144 
   As pointed out in #144 the deadlock arises due to an inversion of locking order:
    - `MessageFilter::add()`, when removing the oldest message, locks:
      - `MessageFilter::messages_mutex_`
      - `BufferCore::transformable_requests_mutex_` (via `cancelTransformableRequest()`)
    - `BufferCore::testTransformableRequests()` locks:
      - `transformable_requests_mutex_`
      - `MessageFilter::message_mutex_` (via `MessageFilter::transformable()` callback)
2. A race condition with `CBQueueCallback`
   When `MessageFilter::signalMessage()` is called asynchronously via a ROS callback queue, this call might still be in progress (holding `Signal1::mutex_`), while another thread might attempt to remove the MessageFilter.
This results in a failed assertion as the MessageFilter's destructor attempts to destroy a locked mutex.

PR #144 attempted to resolve the first issue by postponing callback calls. However, this has the drawback of using references to `TransformableRequests` outside the protection by `transformable_requests_mutex_`. Thus, these requests might get deleted by another thread, resulting in a segfault as revealed by the stress test.
Here the deadlock is resolved in `MessageFilter::add`, canceling the requests outside the `messages_mutex_` protection.

To resolve the second race condition, another mutex is introduced in MessageFilter, to ensure that `CBQueueCallback::call()` is finished before destroying the MessageFilter.

These two changes make the stress test pass.
@tfoote, please note that this is a PR against Melodic. I will prepare a port for Noetic as well.