### PR TITLE
Fix TypeError when using --cache_time argument

### DIFF
--- a/tf2_tools/scripts/echo.py
+++ b/tf2_tools/scripts/echo.py
@@ -139,7 +139,7 @@ def _euler_from_quaternion_msg(quaternion):
 
 class Echo():
     def __init__(self, args):
-        self.tf_buffer = tf2_ros.Buffer(cache_time=args.cache_time)
+        self.tf_buffer = tf2_ros.Buffer(cache_time=rospy.Duration(args.cache_time) if args.cache_time else None)
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
         self.args = args
 


### PR DESCRIPTION
Running `rosrun tf2_tools echo.py --cache_time 1.0 source_frame target_frame` causes `TypeError: time must have a to_sec method, e.g. rospy.Time or rospy.Duration`, because the argument is not properly converted. The fix handles the conversion, if the argument was given.