### PR TITLE
Use only find_package to find bullet.

### DIFF
--- a/tf2_bullet/CMakeLists.txt
+++ b/tf2_bullet/CMakeLists.txt
@@ -1,24 +1,13 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(tf2_bullet)
 
-find_package(PkgConfig REQUIRED)
-
-set(bullet_FOUND 0)
-pkg_check_modules(bullet bullet)
-if(NOT bullet_FOUND)
-    # windows build bullet3 doesn't come with pkg-config by default and it only comes with CMake config files
-    # so pkg_check_modules will fail
-    find_package(bullet REQUIRED)
-
-    # https://github.com/bulletphysics/bullet3/blob/master/BulletConfig.cmake.in
-    set(bullet_INCLUDE_DIRS "${BULLET_INCLUDE_DIRS}")
-endif()
+find_package(Bullet REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs tf2)
 
-include_directories(include ${bullet_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+include_directories(include ${BULLET_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
 
-catkin_package(INCLUDE_DIRS include ${bullet_INCLUDE_DIRS})
+catkin_package(INCLUDE_DIRS include ${BULLET_INCLUDE_DIRS})
 
 install(DIRECTORY include/${PROJECT_NAME}/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/tf2_bullet/package.xml
+++ b/tf2_bullet/package.xml
@@ -11,7 +11,6 @@
   <url type="website">http://www.ros.org/wiki/tf2_bullet</url>
     
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
-  <buildtool_depend>pkg-config</buildtool_depend>
 
   <build_depend>tf2</build_depend>
   <build_depend>bullet</build_depend>


### PR DESCRIPTION
The prior logic was failing on NixOS 23.05; using CMake always should now be safe, as even Bullet 2.88 in Ubuntu Focal contains the CMake module:

```
/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig-float64.cmake
/usr/lib/x86_64-linux-gnu/cmake/bullet/BulletConfig.cmake
/usr/lib/x86_64-linux-gnu/cmake/bullet/UseBullet.cmake
```

https://packages.ubuntu.com/focal/amd64/libbullet-dev/filelist