### PR TITLE
Add missing #include to buffer_core.cpp

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -38,6 +38,7 @@
 #include <console_bridge/console.h>
 #include "tf2/LinearMath/Transform.h"
 #include <boost/foreach.hpp>
+#include <boost/tuple/tuple.hpp>
 
 namespace tf2
 {


### PR DESCRIPTION
This file uses `boost::tuple` without including the associated header.  Changes to Boost 1.84 cause this name to be no loner visible from this .cpp file.