### PR TITLE
Fixed error message when fixed_frame is not found

### DIFF
--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -871,7 +871,7 @@ bool BufferCore::canTransform(const std::string& target_frame, const ros::Time& 
           }
           *error_msg += std::string("canTransform: source_frame " + source_frame + " does not exist.");
         }
-        if (source_id == 0)
+        if (fixed_id == 0)
         {
           if (target_id == 0 || source_id == 0)
           {


### PR DESCRIPTION
Looks like copy&paste error. Should only alter the warning messages, not the behavior of the library.