### PR TITLE
Deprecating tf2 C Headers

### DIFF
--- a/test_tf2/test/buffer_core_test.cpp
+++ b/test_tf2/test/buffer_core_test.cpp
@@ -29,8 +29,8 @@
 
 #include <cmath>
 #include <gtest/gtest.h>
-#include <tf2/buffer_core.h>
-#include "tf2/exceptions.h"
+#include <tf2/buffer_core.hpp>
+#include "tf2/exceptions.hpp"
 #include <ros/ros.h>
 #include "LinearMath/btVector3.h"
 #include "LinearMath/btTransform.h"

--- a/test_tf2/test/test_convert.cpp
+++ b/test_tf2/test/test_convert.cpp
@@ -35,7 +35,7 @@
 * Author: Eitan Marder-Eppstein
 *********************************************************************/
 #include <gtest/gtest.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <tf2_kdl/tf2_kdl.h>
 #include <tf2_bullet/tf2_bullet.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/test_tf2/test/test_message_filter.cpp
+++ b/test_tf2/test/test_message_filter.cpp
@@ -31,7 +31,7 @@
 
 
 #include <tf2_ros/message_filter.h>
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 #include <geometry_msgs/PointStamped.h>
 #include <boost/bind/bind.hpp>
 #include <boost/scoped_ptr.hpp>

--- a/test_tf2/test/test_static_publisher.cpp
+++ b/test_tf2/test/test_static_publisher.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <tf2/buffer_core.h>
-#include "tf2/exceptions.h"
+#include <tf2/buffer_core.hpp>
+#include "tf2/exceptions.hpp"
 #include <tf2_ros/static_transform_broadcaster.h>
 #include <ros/ros.h>
 #include "rostest/permuter.h"

--- a/test_tf2/test/test_tf2_bullet.cpp
+++ b/test_tf2/test/test_tf2_bullet.cpp
@@ -34,7 +34,7 @@
 #include <tf2_ros/buffer.h>
 #include <ros/ros.h>
 #include <gtest/gtest.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 tf2_ros::Buffer* tf_buffer;
 static const double EPS = 1e-3;

--- a/test_tf2/test/test_utils.cpp
+++ b/test_tf2/test/test_utils.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 #include <tf2_kdl/tf2_kdl.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <ros/time.h>

--- a/tf2/include/tf2/convert.h
+++ b/tf2/include/tf2/convert.h
@@ -33,10 +33,10 @@
 #define TF2_CONVERT_H
 
 
-#include <tf2/transform_datatypes.h>
-#include <tf2/exceptions.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/exceptions.hpp>
 #include <geometry_msgs/TransformStamped.h>
-#include <tf2/impl/convert.h>
+#include <tf2/impl/convert.hpp>
 
 namespace tf2 {
 

--- a/tf2/include/tf2/impl/utils.h
+++ b/tf2/include/tf2/impl/utils.h
@@ -16,8 +16,8 @@
 #define TF2_IMPL_UTILS_H
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2/transform_datatypes.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 namespace tf2 {
 namespace impl {

--- a/tf2/include/tf2/transform_storage.h
+++ b/tf2/include/tf2/transform_storage.h
@@ -32,8 +32,8 @@
 #ifndef TF2_TRANSFORM_STORAGE_H
 #define TF2_TRANSFORM_STORAGE_H
 
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <ros/message_forward.h>
 #include <ros/time.h>

--- a/tf2/include/tf2/utils.h
+++ b/tf2/include/tf2/utils.h
@@ -15,13 +15,13 @@
 #ifndef TF2_UTILS_H
 #define TF2_UTILS_H
 
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/impl/utils.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/impl/utils.hpp>
 
 namespace tf2 {
 /** Return the yaw, pitch, roll of anything that can be converted to a tf2::Quaternion
- * The conventions are the usual ROS ones defined in tf2/LineMath/Matrix3x3.h
+ * The conventions are the usual ROS ones defined in tf2/LinearMath/Matrix3x3.hpp
  * \param a the object to get data from (it represents a rotation/quaternion)
  * \param yaw yaw
  * \param pitch pitch
@@ -35,7 +35,7 @@ template <class A>
   }
 
 /** Return the yaw of anything that can be converted to a tf2::Quaternion
- * The conventions are the usual ROS ones defined in tf2/LineMath/Matrix3x3.h
+ * The conventions are the usual ROS ones defined in tf2/LinearMath/Matrix3x3.hpp
  * This function is a specialization of getEulerYPR and is useful for its
  * wide-spread use in navigation
  * \param a the object to get data from (it represents a rotation/quaternion)

--- a/tf2/mainpage.dox
+++ b/tf2/mainpage.dox
@@ -21,7 +21,7 @@ tf2 offers a templated conversion interface for external libraries to specify co
 tf2-specific data types and user-defined data types. Various templated functions in tf2_ros use the
 conversion interface to apply transformations from the tf server to these custom datatypes.
 
-The conversion interface is defined in tf2/convert.h.
+The conversion interface is defined in tf2/convert.hpp.
 
 Some packages that implement this interface:
 

--- a/tf2/src/buffer_core.cpp
+++ b/tf2/src/buffer_core.cpp
@@ -29,14 +29,14 @@
 
 /** \author Tully Foote */
 
-#include "tf2/buffer_core.h"
-#include "tf2/time_cache.h"
-#include "tf2/exceptions.h"
+#include "tf2/buffer_core.hpp"
+#include "tf2/time_cache.hpp"
+#include "tf2/exceptions.hpp"
 #include "tf2_msgs/TF2Error.h"
 
 #include <assert.h>
 #include <console_bridge/console.h>
-#include "tf2/LinearMath/Transform.h"
+#include "tf2/LinearMath/Transform.hpp"
 #include <boost/foreach.hpp>
 #include <boost/tuple/tuple.hpp>
 

--- a/tf2/src/cache.cpp
+++ b/tf2/src/cache.cpp
@@ -29,12 +29,12 @@
 
 /** \author Tully Foote */
 
-#include "tf2/time_cache.h"
-#include "tf2/exceptions.h"
+#include "tf2/time_cache.hpp"
+#include "tf2/exceptions.hpp"
 
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <geometry_msgs/TransformStamped.h>
 #include <assert.h>
 

--- a/tf2/src/static_cache.cpp
+++ b/tf2/src/static_cache.cpp
@@ -29,10 +29,10 @@
 
 /** \author Tully Foote */
 
-#include "tf2/time_cache.h"
-#include "tf2/exceptions.h"
+#include "tf2/time_cache.hpp"
+#include "tf2/exceptions.hpp"
 
-#include "tf2/LinearMath/Transform.h"
+#include "tf2/LinearMath/Transform.hpp"
 
 
 using namespace tf2;

--- a/tf2/test/cache_unittest.cpp
+++ b/tf2/test/cache_unittest.cpp
@@ -28,8 +28,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <tf2/time_cache.h>
-#include "tf2/LinearMath/Quaternion.h"
+#include <tf2/time_cache.hpp>
+#include "tf2/LinearMath/Quaternion.hpp"
 #include <stdexcept>
 
 #include <geometry_msgs/TransformStamped.h>

--- a/tf2/test/simple_tf2_core.cpp
+++ b/tf2/test/simple_tf2_core.cpp
@@ -28,10 +28,10 @@
  */
 
 #include <gtest/gtest.h>
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 #include <ros/time.h>
-#include "tf2/LinearMath/Vector3.h"
-#include "tf2/exceptions.h"
+#include "tf2/LinearMath/Vector3.hpp"
+#include "tf2/exceptions.hpp"
 
 TEST(tf2, setTransformFail)
 {

--- a/tf2/test/speed_test.cpp
+++ b/tf2/test/speed_test.cpp
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <ros/time.h>
 #include <console_bridge/console.h>

--- a/tf2/test/static_cache_test.cpp
+++ b/tf2/test/static_cache_test.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <tf2/time_cache.h>
+#include <tf2/time_cache.hpp>
 #include <stdexcept>
 
 #include <geometry_msgs/TransformStamped.h>

--- a/tf2/test/test_transform_datatypes.cpp
+++ b/tf2/test/test_transform_datatypes.cpp
@@ -28,7 +28,7 @@
  */
 #include <gtest/gtest.h>
 
-#include "tf2/transform_datatypes.h"
+#include "tf2/transform_datatypes.hpp"
 
 #include <string>
 

--- a/tf2_bullet/include/tf2_bullet/tf2_bullet.h
+++ b/tf2_bullet/include/tf2_bullet/tf2_bullet.h
@@ -32,7 +32,7 @@
 #ifndef TF2_BULLET_H
 #define TF2_BULLET_H
 
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <LinearMath/btTransform.h>
 #include <geometry_msgs/PointStamped.h>
 
@@ -53,7 +53,7 @@ btTransform transformToBullet(const geometry_msgs::TransformStamped& t)
 
 
 /** \brief Apply a geometry_msgs TransformStamped to a Bullet-specific Vector3 type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp
  * \param t_in The vector to transform, as a timestamped Bullet btVector3 data type.
  * \param t_out The transformed vector, as a timestamped Bullet btVector3 data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -66,7 +66,7 @@ inline
   }
 
 /** \brief Convert a stamped Bullet Vector3 type to a PointStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp
  * \param in The timestamped Bullet btVector3 to convert.
  * \return The vector converted to a PointStamped message.
  */
@@ -83,7 +83,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<btVector3>& in)
 }
 
 /** \brief Convert a PointStamped message type to a stamped Bullet-specific Vector3 type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The PointStamped message to convert.
  * \param out The point converted to a timestamped Bullet Vector3.
  */
@@ -99,7 +99,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<btVector3>& ou
 
 
 /** \brief Apply a geometry_msgs TransformStamped to a Bullet-specific Transform data type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp
  * \param t_in The frame to transform, as a timestamped Bullet btTransform.
  * \param t_out The transformed frame, as a timestamped Bullet btTransform.
  * \param transform The timestamped transform to apply, as a TransformStamped message.

--- a/tf2_bullet/mainpage.dox
+++ b/tf2_bullet/mainpage.dox
@@ -14,6 +14,6 @@ wiki page for more information about datatype conversion in tf2.
 \section codeapi Code API 
 
 This library consists of one header only, tf2_bullet/tf2_bullet.h, which consists mostly of
-specializations of template functions defined in tf2/convert.h.
+specializations of template functions defined in tf2/convert.hpp.
 
 */

--- a/tf2_bullet/test/test_tf2_bullet.cpp
+++ b/tf2_bullet/test/test_tf2_bullet.cpp
@@ -32,7 +32,7 @@
 
 #include <tf2_bullet/tf2_bullet.h>
 #include <gtest/gtest.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 static const double EPS = 1e-3;
 

--- a/tf2_eigen/include/tf2_eigen/tf2_eigen.h
+++ b/tf2_eigen/include/tf2_eigen/tf2_eigen.h
@@ -29,7 +29,7 @@
 #ifndef TF2_EIGEN_H
 #define TF2_EIGEN_H
 
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <Eigen/Geometry>
 #include <geometry_msgs/QuaternionStamped.h>
 #include <geometry_msgs/PointStamped.h>
@@ -102,7 +102,7 @@ geometry_msgs::TransformStamped eigenToTransform(const Eigen::Isometry3d& T)
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
  * functions rely on the existence of a time stamp and a frame id in the type which should
  * get transformed.
@@ -118,7 +118,7 @@ void doTransform(const Eigen::Vector3d& t_in, Eigen::Vector3d& t_out, const geom
 }
 
 /** \brief Convert a Eigen Vector3d type to a Point message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped Eigen Vector3d to convert.
  * \return The vector converted to a Point message.
  */
@@ -133,7 +133,7 @@ geometry_msgs::Point toMsg(const Eigen::Vector3d& in)
 }
 
 /** \brief Convert a Point message type to a Eigen-specific Vector3d type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The Point message to convert.
  * \param out The point converted to a Eigen Vector3d.
  */
@@ -146,7 +146,7 @@ void fromMsg(const geometry_msgs::Point& msg, Eigen::Vector3d& out)
 }
 
 /** \brief Convert an Eigen Vector3d type to a Vector3 message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The Eigen Vector3d to convert.
  * \return The vector converted to a Vector3 message.
  */
@@ -160,7 +160,7 @@ geometry_msgs::Vector3& toMsg(const Eigen::Vector3d& in, geometry_msgs::Vector3&
 }
 
 /** \brief Convert a Vector3 message type to a Eigen-specific Vector3d type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The Vector3 message to convert.
  * \param out The vector converted to a Eigen Vector3d.
  */
@@ -173,7 +173,7 @@ void fromMsg(const geometry_msgs::Vector3& msg, Eigen::Vector3d& out)
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Vector3d type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The vector to transform, as a timestamped Eigen Vector3d data type.
  * \param t_out The transformed vector, as a timestamped Eigen Vector3d data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -189,7 +189,7 @@ void doTransform(const tf2::Stamped<Eigen::Vector3d>& t_in,
 }
 
 /** \brief Convert a stamped Eigen Vector3d type to a PointStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped Eigen Vector3d to convert.
  * \return The vector converted to a PointStamped message.
  */
@@ -204,7 +204,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<Eigen::Vector3d>& in)
 }
 
 /** \brief Convert a PointStamped message type to a stamped Eigen-specific Vector3d type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The PointStamped message to convert.
  * \param out The point converted to a timestamped Eigen Vector3d.
  */
@@ -216,7 +216,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<Eigen::Vector3
 }
 
 /** \brief Apply a geometry_msgs Transform to an Eigen Affine3d transform.
- * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
  * function relies on the existence of a time stamp and a frame id in the type which should
  * get transformed.
@@ -241,7 +241,7 @@ void doTransform(const Eigen::Isometry3d& t_in,
 }
 
 /** \brief Convert a Eigen Quaterniond type to a Quaternion message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The Eigen Quaterniond to convert.
  * \return The quaternion converted to a Quaterion message.
  */
@@ -256,7 +256,7 @@ geometry_msgs::Quaternion toMsg(const Eigen::Quaterniond& in) {
 }
 
 /** \brief Convert a Quaternion message type to a Eigen-specific Quaterniond type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The Quaternion message to convert.
  * \param out The quaternion converted to a Eigen Quaterniond.
  */
@@ -266,7 +266,7 @@ void fromMsg(const geometry_msgs::Quaternion& msg, Eigen::Quaterniond& out) {
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Quaterniond type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
  * functions rely on the existence of a time stamp and a frame id in the type which should
  * get transformed.
@@ -285,7 +285,7 @@ void doTransform(const Eigen::Quaterniond& t_in,
 }
 
 /** \brief Convert a stamped Eigen Quaterniond type to a QuaternionStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped Eigen Quaterniond to convert.
  * \return The quaternion converted to a QuaternionStamped message.
  */
@@ -299,7 +299,7 @@ geometry_msgs::QuaternionStamped toMsg(const Stamped<Eigen::Quaterniond>& in) {
 }
 
 /** \brief Convert a QuaternionStamped message type to a stamped Eigen-specific Quaterniond type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The QuaternionStamped message to convert.
  * \param out The quaternion converted to a timestamped Eigen Quaterniond.
  */
@@ -311,7 +311,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& msg, Stamped<Eigen::Quatern
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen-specific Quaterniond type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The vector to transform, as a timestamped Eigen Quaterniond data type.
  * \param t_out The transformed vector, as a timestamped Eigen Quaterniond data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -327,7 +327,7 @@ void doTransform(const tf2::Stamped<Eigen::Quaterniond>& t_in,
 }
 
 /** \brief Convert a Eigen Affine3d transform type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The Eigen Affine3d to convert.
  * \return The Eigen transform converted to a Pose message.
  */
@@ -352,7 +352,7 @@ geometry_msgs::Pose toMsg(const Eigen::Affine3d& in) {
 }
 
 /** \brief Convert a Eigen Isometry3d transform type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The Eigen Isometry3d to convert.
  * \return The Eigen transform converted to a Pose message.
  */
@@ -377,7 +377,7 @@ geometry_msgs::Pose toMsg(const Eigen::Isometry3d& in) {
 }
 
 /** \brief Convert a Pose message transform type to a Eigen Affine3d.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg The Pose message to convert.
  * \param out The pose converted to a Eigen Affine3d.
  */
@@ -392,7 +392,7 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Affine3d& out) {
 }
 
 /** \brief Convert a Pose message transform type to a Eigen Isometry3d.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg The Pose message to convert.
  * \param out The pose converted to a Eigen Isometry3d.
  */
@@ -407,7 +407,7 @@ void fromMsg(const geometry_msgs::Pose& msg, Eigen::Isometry3d& out) {
 }
 
 /** \brief Convert a Eigen 6x1 Matrix type to a Twist message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The 6x1 Eigen Matrix to convert.
  * \return The Eigen Matrix converted to a Twist message.
  */
@@ -424,7 +424,7 @@ geometry_msgs::Twist toMsg(const Eigen::Matrix<double,6,1>& in) {
 }
 
 /** \brief Convert a Twist message transform type to a Eigen 6x1 Matrix.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg The Twist message to convert.
  * \param out The twist converted to a Eigen 6x1 Matrix.
  */
@@ -439,7 +439,7 @@ void fromMsg(const geometry_msgs::Twist &msg, Eigen::Matrix<double,6,1>& out) {
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen Affine3d transform.
- * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
  * function relies on the existence of a time stamp and a frame id in the type which should
  * get transformed.
@@ -456,7 +456,7 @@ void doTransform(const tf2::Stamped<Eigen::Affine3d>& t_in,
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an Eigen Isometry transform.
- * This function is a specialization of the doTransform template defined in tf2/convert.h,
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp,
  * although it can not be used in tf2_ros::BufferInterface::transform because this
  * function relies on the existence of a time stamp and a frame id in the type which should
  * get transformed.
@@ -473,7 +473,7 @@ void doTransform(const tf2::Stamped<Eigen::Isometry3d>& t_in,
 }
 
 /** \brief Convert a stamped Eigen Affine3d transform type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped Eigen Affine3d to convert.
  * \return The Eigen transform converted to a PoseStamped message.
  */
@@ -498,7 +498,7 @@ geometry_msgs::PoseStamped toMsg(const tf2::Stamped<Eigen::Isometry3d>& in)
 }
 
 /** \brief Convert a Pose message transform type to a stamped Eigen Affine3d.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg The PoseStamped message to convert.
  * \param out The pose converted to a timestamped Eigen Affine3d.
  */

--- a/tf2_eigen/mainpage.dox
+++ b/tf2_eigen/mainpage.dox
@@ -14,6 +14,6 @@ wiki page for more information about datatype conversion in tf2.
 \section codeapi Code API 
 
 This library consists of one header only, tf2_eigen/tf2_eigen.h, which consists mostly of
-specializations of template functions defined in tf2/convert.h.
+specializations of template functions defined in tf2/convert.hpp.
 
 */

--- a/tf2_eigen/test/tf2_eigen-test.cpp
+++ b/tf2_eigen/test/tf2_eigen-test.cpp
@@ -29,7 +29,7 @@
 
 #include <tf2_eigen/tf2_eigen.h>
 #include <gtest/gtest.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 TEST(TfEigen, ConvertVector3dStamped)
 {

--- a/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
+++ b/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h
@@ -32,9 +32,9 @@
 #ifndef TF2_GEOMETRY_MSGS_H
 #define TF2_GEOMETRY_MSGS_H
 
-#include <tf2/convert.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/convert.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 #include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/QuaternionStamped.h>
 #include <geometry_msgs/TransformStamped.h>
@@ -74,7 +74,7 @@ KDL::Frame gmTransformToKDL(const geometry_msgs::TransformStamped& t)
 /*************/
 
 /** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A tf2 Vector3 object.
  * \return The Vector3 converted to a geometry_msgs message type.
  */
@@ -89,7 +89,7 @@ geometry_msgs::Vector3 toMsg(const tf2::Vector3& in)
 }
 
 /** \brief Convert a Vector3 message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param in A Vector3 message type.
  * \param out The Vector3 converted to a tf2 type.
  */
@@ -105,7 +105,7 @@ void fromMsg(const geometry_msgs::Vector3& in, tf2::Vector3& out)
 /********************/
 
 /** \brief Extract a timestamp from the header of a Vector message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t VectorStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
  * is bound to the lifetime of the argument.
@@ -115,7 +115,7 @@ inline
   const ros::Time& getTimestamp(const geometry_msgs::Vector3Stamped& t) {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a Vector message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t VectorStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
  * returned reference is bound to the lifetime of the argument.
@@ -126,7 +126,7 @@ inline
 
 
 /** \brief Trivial "conversion" function for Vector3 message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A Vector3Stamped message.
  * \return The input argument.
  */
@@ -137,7 +137,7 @@ geometry_msgs::Vector3Stamped toMsg(const geometry_msgs::Vector3Stamped& in)
 }
 
 /** \brief Trivial "conversion" function for Vector3 message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A Vector3Stamped message.
  * \param out The input argument.
  */
@@ -148,7 +148,7 @@ void fromMsg(const geometry_msgs::Vector3Stamped& msg, geometry_msgs::Vector3Sta
 }
 
 /** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
  * \return The Vector3Stamped converted to a geometry_msgs Vector3Stamped message type.
  */
@@ -165,7 +165,7 @@ geometry_msgs::Vector3Stamped toMsg(const tf2::Stamped<tf2::Vector3>& in)
 }
 
 /** \brief Convert a Vector3Stamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A Vector3Stamped message.
  * \param out The Vector3Stamped converted to the equivalent tf2 type.
  */
@@ -183,7 +183,7 @@ void fromMsg(const geometry_msgs::Vector3Stamped& msg, tf2::Stamped<tf2::Vector3
 /***********/
 
 /** \brief Convert a tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A tf2 Vector3 object.
  * \return The Vector3 converted to a geometry_msgs message type.
  */
@@ -197,7 +197,7 @@ geometry_msgs::Point& toMsg(const tf2::Vector3& in, geometry_msgs::Point& out)
 }
 
 /** \brief Convert a Vector3 message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param in A Vector3 message type.
  * \param out The Vector3 converted to a tf2 type.
  */
@@ -213,7 +213,7 @@ void fromMsg(const geometry_msgs::Point& in, tf2::Vector3& out)
 /******************/
 
 /** \brief Extract a timestamp from the header of a Point message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t PointStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
  * is bound to the lifetime of the argument.
@@ -223,7 +223,7 @@ inline
   const ros::Time& getTimestamp(const geometry_msgs::PointStamped& t)  {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a Point message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t PointStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
  * returned reference is bound to the lifetime of the argument.
@@ -233,7 +233,7 @@ inline
   const std::string& getFrameId(const geometry_msgs::PointStamped& t)  {return t.header.frame_id;}
 
 /** \brief Trivial "conversion" function for Point message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A PointStamped message.
  * \return The input argument.
  */
@@ -244,7 +244,7 @@ geometry_msgs::PointStamped toMsg(const geometry_msgs::PointStamped& in)
 }
 
 /** \brief Trivial "conversion" function for Point message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A PointStamped message.
  * \param out The input argument.
  */
@@ -255,7 +255,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, geometry_msgs::PointStamped
 }
 
 /** \brief Convert as stamped tf2 Vector3 type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Vector3 specialization of the tf2::Stamped template.
  * \return The Vector3Stamped converted to a geometry_msgs PointStamped message type.
  */
@@ -271,7 +271,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<tf2::Vector3>& in, geometry
 }
 
 /** \brief Convert a PointStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A PointStamped message.
  * \param out The PointStamped converted to the equivalent tf2 type.
  */
@@ -289,7 +289,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<tf2::Vector3>&
 /****************/
 
 /** \brief Convert a tf2 Quaternion type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A tf2 Quaternion object.
  * \return The Quaternion converted to a geometry_msgs message type.
  */
@@ -305,7 +305,7 @@ geometry_msgs::Quaternion toMsg(const tf2::Quaternion& in)
 }
 
 /** \brief Convert a Quaternion message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param in A Quaternion message type.
  * \param out The Quaternion converted to a tf2 type.
  */
@@ -322,7 +322,7 @@ void fromMsg(const geometry_msgs::Quaternion& in, tf2::Quaternion& out)
 /***********************/
 
 /** \brief Extract a timestamp from the header of a Quaternion message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t QuaternionStamped message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
  * is bound to the lifetime of the argument.
@@ -332,7 +332,7 @@ inline
 const ros::Time& getTimestamp(const geometry_msgs::QuaternionStamped& t)  {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a Quaternion message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t QuaternionStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
  * returned reference is bound to the lifetime of the argument.
@@ -342,7 +342,7 @@ inline
 const std::string& getFrameId(const geometry_msgs::QuaternionStamped& t)  {return t.header.frame_id;}
 
 /** \brief Trivial "conversion" function for Quaternion message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A QuaternionStamped message.
  * \return The input argument.
  */
@@ -353,7 +353,7 @@ geometry_msgs::QuaternionStamped toMsg(const geometry_msgs::QuaternionStamped& i
 }
 
 /** \brief Trivial "conversion" function for Quaternion message type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A QuaternionStamped message.
  * \param out The input argument.
  */
@@ -364,7 +364,7 @@ void fromMsg(const geometry_msgs::QuaternionStamped& msg, geometry_msgs::Quatern
 }
 
 /** \brief Convert as stamped tf2 Quaternion type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Quaternion specialization of the tf2::Stamped template.
  * \return The QuaternionStamped converted to a geometry_msgs QuaternionStamped message type.
  */
@@ -395,7 +395,7 @@ geometry_msgs::QuaternionStamped toMsg(const tf2::Stamped<tf2::Quaternion>& in)
 }
 
 /** \brief Convert a QuaternionStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param in A QuaternionStamped message type.
  * \param out The QuaternionStamped converted to the equivalent tf2 type.
  */
@@ -456,7 +456,7 @@ void fromMsg(const geometry_msgs::Pose& in, tf2::Transform& out)
 /*****************/
 
 /** \brief Extract a timestamp from the header of a Pose message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t PoseStamped message to extract the timestamp from.
  * \return The timestamp of the message.
  */
@@ -465,7 +465,7 @@ inline
   const ros::Time& getTimestamp(const geometry_msgs::PoseStamped& t)  {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a Pose message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t PoseStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message.
  */
@@ -474,7 +474,7 @@ inline
   const std::string& getFrameId(const geometry_msgs::PoseStamped& t)  {return t.header.frame_id;}
 
 /** \brief Trivial "conversion" function for Pose message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A PoseStamped message.
  * \return The input argument.
  */
@@ -485,7 +485,7 @@ geometry_msgs::PoseStamped toMsg(const geometry_msgs::PoseStamped& in)
 }
 
 /** \brief Trivial "conversion" function for Pose message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg A PoseStamped message.
  * \param out The input argument.
  */
@@ -496,7 +496,7 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, geometry_msgs::PoseStamped& 
 }
 
 /** \brief Convert as stamped tf2 Pose type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Pose specialization of the tf2::Stamped template.
  * \return The PoseStamped converted to a geometry_msgs PoseStamped message type.
  */
@@ -511,7 +511,7 @@ geometry_msgs::PoseStamped toMsg(const tf2::Stamped<tf2::Transform>& in, geometr
 }
 
 /** \brief Convert a PoseStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A PoseStamped message.
  * \param out The PoseStamped converted to the equivalent tf2 type.
  */
@@ -530,7 +530,7 @@ void fromMsg(const geometry_msgs::PoseStamped& msg, tf2::Stamped<tf2::Transform>
 /*******************************/
 
 /** \brief Extract a timestamp from the header of a PoseWithCovarianceStamped message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t PoseWithCovarianceStamped message to extract the timestamp from.
  * \return The timestamp of the message.
  */
@@ -539,7 +539,7 @@ inline
   const ros::Time& getTimestamp(const geometry_msgs::PoseWithCovarianceStamped& t)  {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a PoseWithCovarianceStamped message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t PoseWithCovarianceStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message.
  */
@@ -548,7 +548,7 @@ inline
   const std::string& getFrameId(const geometry_msgs::PoseWithCovarianceStamped& t)  {return t.header.frame_id;}
 
 /** \brief Trivial "conversion" function for PoseWithCovarianceStamped message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A PoseWithCovarianceStamped message.
  * \return The input argument.
  */
@@ -559,7 +559,7 @@ geometry_msgs::PoseWithCovarianceStamped toMsg(const geometry_msgs::PoseWithCova
 }
 
 /** \brief Trivial "conversion" function for PoseWithCovarianceStamped message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg A PoseWithCovarianceStamped message.
  * \param out The input argument.
  */
@@ -570,7 +570,7 @@ void fromMsg(const geometry_msgs::PoseWithCovarianceStamped& msg, geometry_msgs:
 }
 
 /** \brief Convert as stamped tf2 PoseWithCovarianceStamped type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Pose specialization of the tf2::Stamped template.
  * \return The PoseWithCovarianceStamped converted to a geometry_msgs PoseWithCovarianceStamped message type.
  */
@@ -585,7 +585,7 @@ geometry_msgs::PoseWithCovarianceStamped toMsg(const tf2::Stamped<tf2::Transform
 }
 
 /** \brief Convert a PoseWithCovarianceStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A PoseWithCovarianceStamped message.
  * \param out The PoseWithCovarianceStamped converted to the equivalent tf2 type.
  */
@@ -604,7 +604,7 @@ void fromMsg(const geometry_msgs::PoseWithCovarianceStamped& msg, tf2::Stamped<t
 /***************/
 
 /** \brief Convert a tf2 Transform type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A tf2 Transform object.
  * \return The Transform converted to a geometry_msgs message type.
  */
@@ -618,7 +618,7 @@ geometry_msgs::Transform toMsg(const tf2::Transform& in)
 }
 
 /** \brief Convert a Transform message to its equivalent tf2 representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A Transform message type.
  * \param out The Transform converted to a tf2 type.
  */
@@ -640,7 +640,7 @@ void fromMsg(const geometry_msgs::Transform& in, tf2::Transform& out)
 /**********************/
 
 /** \brief Extract a timestamp from the header of a Transform message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t TransformStamped message to extract the timestamp from.
  * \return The timestamp of the message.
  */
@@ -649,7 +649,7 @@ inline
 const ros::Time& getTimestamp(const geometry_msgs::TransformStamped& t)  {return t.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a Transform message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t TransformStamped message to extract the frame ID from.
  * \return A string containing the frame ID of the message.
  */
@@ -658,7 +658,7 @@ inline
 const std::string& getFrameId(const geometry_msgs::TransformStamped& t)  {return t.header.frame_id;}
 
 /** \brief Trivial "conversion" function for Transform message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in A TransformStamped message.
  * \return The input argument.
  */
@@ -668,7 +668,7 @@ geometry_msgs::TransformStamped toMsg(const geometry_msgs::TransformStamped& in)
   return in;
 }
 /** \brief Trivial "conversion" function for TransformStamped message type.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param msg A TransformStamped message.
  * \param out The input argument.
  */
@@ -679,7 +679,7 @@ void fromMsg(const geometry_msgs::TransformStamped& msg, geometry_msgs::Transfor
 }
 
 /** \brief Convert as stamped tf2 Transform type to its equivalent geometry_msgs representation.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in An instance of the tf2::Transform specialization of the tf2::Stamped template.
  * \return The tf2::Stamped<tf2::Transform> converted to a geometry_msgs TransformStamped message type.
  */
@@ -696,7 +696,7 @@ geometry_msgs::TransformStamped toMsg(const tf2::Stamped<tf2::Transform>& in)
 
 
 /** \brief Convert a TransformStamped message to its equivalent tf2 representation.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg A TransformStamped message.
  * \param out The TransformStamped converted to the equivalent tf2 type.
  */
@@ -711,7 +711,7 @@ void fromMsg(const geometry_msgs::TransformStamped& msg, tf2::Stamped<tf2::Trans
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Point type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The point to transform, as a Point3 message.
  * \param t_out The transformed point, as a Point3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -729,7 +729,7 @@ inline
   }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Point type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The point to transform, as a timestamped Point3 message.
  * \param t_out The transformed point, as a timestamped Point3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -744,7 +744,7 @@ inline
   }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Quaternion type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The quaternion to transform, as a Quaternion3 message.
  * \param t_out The transformed quaternion, as a Quaternion3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -762,7 +762,7 @@ void doTransform(const geometry_msgs::Quaternion& t_in, geometry_msgs::Quaternio
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Quaternion type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The quaternion to transform, as a timestamped Quaternion3 message.
  * \param t_out The transformed quaternion, as a timestamped Quaternion3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -778,7 +778,7 @@ void doTransform(const geometry_msgs::QuaternionStamped& t_in, geometry_msgs::Qu
 
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Pose type.
-* This function is a specialization of the doTransform template defined in tf2/convert.h.
+* This function is a specialization of the doTransform template defined in tf2/convert.hpp.
 * \param t_in The pose to transform, as a Pose3 message.
 * \param t_out The transformed pose, as a Pose3 message.
 * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -799,7 +799,7 @@ void doTransform(const geometry_msgs::Pose& t_in, geometry_msgs::Pose& t_out, co
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Pose type.
-* This function is a specialization of the doTransform template defined in tf2/convert.h.
+* This function is a specialization of the doTransform template defined in tf2/convert.hpp.
 * \param t_in The pose to transform, as a timestamped Pose3 message.
 * \param t_out The transformed pose, as a timestamped Pose3 message.
 * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -902,7 +902,7 @@ geometry_msgs::PoseWithCovariance::_covariance_type transformCovariance(const ge
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs PoseWithCovarianceStamped type.
-* This function is a specialization of the doTransform template defined in tf2/convert.h.
+* This function is a specialization of the doTransform template defined in tf2/convert.hpp.
 * \param t_in The pose to transform, as a timestamped PoseWithCovarianceStamped message.
 * \param t_out The transformed pose, as a timestamped PoseWithCovarianceStamped message.
 * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -927,7 +927,7 @@ void doTransform(const geometry_msgs::PoseWithCovarianceStamped& t_in, geometry_
 }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Transform type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The frame to transform, as a timestamped Transform3 message.
  * \param t_out The frame transform, as a timestamped Transform3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -949,7 +949,7 @@ void doTransform(const geometry_msgs::TransformStamped& t_in, geometry_msgs::Tra
   }
 
 /** \brief Apply a geometry_msgs TransformStamped to an geometry_msgs Vector type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The vector to transform, as a Vector3 message.
  * \param t_out The transformed vector, as a Vector3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -967,7 +967,7 @@ inline
   }
 
 /** \brief Apply a geometry_msgs TransformStamped to an stamped geometry_msgs Vector type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The vector to transform, as a timestamped Vector3 message.
  * \param t_out The transformed vector, as a timestamped Vector3 message.
  * \param transform The timestamped transform to apply, as a TransformStamped message.

--- a/tf2_geometry_msgs/mainpage.dox
+++ b/tf2_geometry_msgs/mainpage.dox
@@ -14,6 +14,6 @@ wiki page for more information about datatype conversion in tf2.
 \section codeapi Code API 
 
 This library consists of one header only, tf2_geometry_msgs/tf2_geometry_msgs.h, which consists mostly of
-specializations of template functions defined in tf2/convert.h.
+specializations of template functions defined in tf2/convert.hpp.
 
 */

--- a/tf2_kdl/include/tf2_kdl/tf2_kdl.h
+++ b/tf2_kdl/include/tf2_kdl/tf2_kdl.h
@@ -32,7 +32,7 @@
 #ifndef TF2_KDL_H
 #define TF2_KDL_H
 
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <kdl/frames.hpp>
 #include <geometry_msgs/PointStamped.h>
 #include <geometry_msgs/TwistStamped.h>
@@ -74,7 +74,7 @@ geometry_msgs::TransformStamped kdlToTransform(const KDL::Frame& k)
 // Vector
 // ---------------------
 /** \brief Apply a geometry_msgs TransformStamped to an KDL-specific Vector type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The vector to transform, as a timestamped KDL Vector data type.
  * \param t_out The transformed vector, as a timestamped KDL Vector data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -87,7 +87,7 @@ inline
   }
 
 /** \brief Convert a stamped KDL Vector type to a PointStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped KDL Vector to convert.
  * \return The vector converted to a PointStamped message.
  */
@@ -104,7 +104,7 @@ geometry_msgs::PointStamped toMsg(const tf2::Stamped<KDL::Vector>& in)
 }
 
 /** \brief Convert a PointStamped message type to a stamped KDL-specific Vector type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The PointStamped message to convert.
  * \param out The point converted to a timestamped KDL Vector.
  */
@@ -122,7 +122,7 @@ void fromMsg(const geometry_msgs::PointStamped& msg, tf2::Stamped<KDL::Vector>& 
 // Twist
 // ---------------------
 /** \brief Apply a geometry_msgs TransformStamped to an KDL-specific Twist type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The twist to transform, as a timestamped KDL Twist data type.
  * \param t_out The transformed Twist, as a timestamped KDL Frame data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -135,7 +135,7 @@ inline
   }
 
 /** \brief Convert a stamped KDL Twist type to a TwistStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped KDL Twist to convert.
  * \return The twist converted to a TwistStamped message.
  */
@@ -155,7 +155,7 @@ geometry_msgs::TwistStamped toMsg(const tf2::Stamped<KDL::Twist>& in)
 }
 
 /** \brief Convert a TwistStamped message type to a stamped KDL-specific Twist type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The TwistStamped message to convert.
  * \param out The twist converted to a timestamped KDL Twist.
  */
@@ -177,7 +177,7 @@ void fromMsg(const geometry_msgs::TwistStamped& msg, tf2::Stamped<KDL::Twist>& o
 // Wrench
 // ---------------------
 /** \brief Apply a geometry_msgs TransformStamped to an KDL-specific Wrench type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The wrench to transform, as a timestamped KDL Wrench data type.
  * \param t_out The transformed Wrench, as a timestamped KDL Frame data type.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -190,7 +190,7 @@ inline
   }
 
 /** \brief Convert a stamped KDL Wrench type to a WrenchStamped message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped KDL Wrench to convert.
  * \return The wrench converted to a WrenchStamped message.
  */
@@ -210,7 +210,7 @@ geometry_msgs::WrenchStamped toMsg(const tf2::Stamped<KDL::Wrench>& in)
 }
 
 /** \brief Convert a WrenchStamped message type to a stamped KDL-specific Wrench type.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp
  * \param msg The WrenchStamped message to convert.
  * \param out The wrench converted to a timestamped KDL Wrench.
  */
@@ -234,7 +234,7 @@ void fromMsg(const geometry_msgs::WrenchStamped& msg, tf2::Stamped<KDL::Wrench>&
 // Frame
 // ---------------------
 /** \brief Apply a geometry_msgs TransformStamped to a KDL-specific Frame data type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
+ * This function is a specialization of the doTransform template defined in tf2/convert.hpp.
  * \param t_in The frame to transform, as a timestamped KDL Frame.
  * \param t_out The transformed frame, as a timestamped KDL Frame.
  * \param transform The timestamped transform to apply, as a TransformStamped message.
@@ -247,7 +247,7 @@ inline
   }
 
 /** \brief Convert a stamped KDL Frame type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped KDL Frame to convert.
  * \return The frame converted to a Pose message.
  */
@@ -263,7 +263,7 @@ geometry_msgs::Pose toMsg(const KDL::Frame& in)
 }
 
 /** \brief Convert a Pose message type to a KDL Frame.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg The Pose message to convert.
  * \param out The pose converted to a KDL Frame.
  */
@@ -277,7 +277,7 @@ void fromMsg(const geometry_msgs::Pose& msg, KDL::Frame& out)
 }
 
 /** \brief Convert a stamped KDL Frame type to a Pose message.
- * This function is a specialization of the toMsg template defined in tf2/convert.h.
+ * This function is a specialization of the toMsg template defined in tf2/convert.hpp.
  * \param in The timestamped KDL Frame to convert.
  * \return The frame converted to a PoseStamped message.
  */
@@ -292,7 +292,7 @@ geometry_msgs::PoseStamped toMsg(const tf2::Stamped<KDL::Frame>& in)
 }
 
 /** \brief Convert a Pose message transform type to a stamped KDL Frame.
- * This function is a specialization of the fromMsg template defined in tf2/convert.h.
+ * This function is a specialization of the fromMsg template defined in tf2/convert.hpp.
  * \param msg The PoseStamped message to convert.
  * \param out The pose converted to a timestamped KDL Frame.
  */

--- a/tf2_kdl/mainpage.dox
+++ b/tf2_kdl/mainpage.dox
@@ -14,6 +14,6 @@ wiki page for more information about datatype conversion in tf2.
 \section codeapi Code API 
 
 This library consists of one header only, tf2_kdl/tf2_kdl.h, which consists mostly of
-specializations of template functions defined in tf2/convert.h.
+specializations of template functions defined in tf2/convert.hpp.
 
 */

--- a/tf2_py/src/tf2_py.cpp
+++ b/tf2_py/src/tf2_py.cpp
@@ -1,7 +1,7 @@
 #include <Python.h>
 
-#include <tf2/buffer_core.h>
-#include <tf2/exceptions.h>
+#include <tf2/buffer_core.hpp>
+#include <tf2/exceptions.hpp>
 
 #include "python_compat.h"
 

--- a/tf2_ros/include/tf2_ros/buffer.h
+++ b/tf2_ros/include/tf2_ros/buffer.h
@@ -33,10 +33,10 @@
 #define TF2_ROS_BUFFER_H
 
 #include <tf2_ros/buffer_interface.h>
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 #include <tf2_msgs/FrameGraph.h>
 #include <ros/ros.h>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 
 namespace tf2_ros

--- a/tf2_ros/include/tf2_ros/buffer_interface.h
+++ b/tf2_ros/include/tf2_ros/buffer_interface.h
@@ -32,12 +32,12 @@
 #ifndef TF2_ROS_BUFFER_INTERFACE_H
 #define TF2_ROS_BUFFER_INTERFACE_H
 
-#include <tf2/buffer_core.h>
-#include <tf2/transform_datatypes.h>
-#include <tf2/exceptions.h>
+#include <tf2/buffer_core.hpp>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/exceptions.hpp>
 #include <geometry_msgs/TransformStamped.h>
 #include <sstream>
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 
 namespace tf2_ros
 {

--- a/tf2_ros/include/tf2_ros/message_filter.h
+++ b/tf2_ros/include/tf2_ros/message_filter.h
@@ -32,7 +32,7 @@
 #ifndef TF2_ROS_MESSAGE_FILTER_H
 #define TF2_ROS_MESSAGE_FILTER_H
 
-#include <tf2/buffer_core.h>
+#include <tf2/buffer_core.hpp>
 
 #include <string>
 #include <list>

--- a/tf2_ros/src/static_transform_broadcaster_program.cpp
+++ b/tf2_ros/src/static_transform_broadcaster_program.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <cstdio>
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 #include "tf2_ros/static_transform_broadcaster.h"
 
 

--- a/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
+++ b/tf2_sensor_msgs/include/tf2_sensor_msgs/tf2_sensor_msgs.h
@@ -30,7 +30,7 @@
 #ifndef TF2_SENSOR_MSGS_H
 #define TF2_SENSOR_MSGS_H
 
-#include <tf2/convert.h>
+#include <tf2/convert.hpp>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud2_iterator.h>
 #include <Eigen/Eigen>
@@ -44,7 +44,7 @@ namespace tf2
 /********************/
 
 /** \brief Extract a timestamp from the header of a PointCloud2 message.
- * This function is a specialization of the getTimestamp template defined in tf2/convert.h.
+ * This function is a specialization of the getTimestamp template defined in tf2/convert.hpp.
  * \param t PointCloud2 message to extract the timestamp from.
  * \return The timestamp of the message. The lifetime of the returned reference
  * is bound to the lifetime of the argument.
@@ -54,7 +54,7 @@ inline
 const ros::Time& getTimestamp(const sensor_msgs::PointCloud2& p) {return p.header.stamp;}
 
 /** \brief Extract a frame ID from the header of a PointCloud2 message.
- * This function is a specialization of the getFrameId template defined in tf2/convert.h.
+ * This function is a specialization of the getFrameId template defined in tf2/convert.hpp.
  * \param t PointCloud2 message to extract the frame ID from.
  * \return A string containing the frame ID of the message. The lifetime of the
  * returned reference is bound to the lifetime of the argument.


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.

Edit: I should mention this is meant to be a preemptive PR for if/when the related pull request gets approved. I'm also working on a backport so there won't be distribution issues